### PR TITLE
refactor: demote per-call gRPC discovery DEBUG logs to TRACE

### DIFF
--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/ChannelManager.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/ChannelManager.java
@@ -212,7 +212,7 @@ public class ChannelManager {
             // If we got here via the loader, it was a miss. Otherwise a hit.
             // Caffeine doesn't distinguish, so we record hits separately.
             // The miss is recorded inside the loader above.
-            LOG.debugf("Returning gRPC channel for service: %s", serviceName);
+            LOG.tracef("Returning gRPC channel for service: %s", serviceName);
             return Uni.createFrom().item(channel);
         } catch (Exception e) {
             // Caffeine wraps loader exceptions in CompletionException

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/DynamicGrpcClientFactory.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/DynamicGrpcClientFactory.java
@@ -97,15 +97,15 @@ public class DynamicGrpcClientFactory implements GrpcClientFactory {
             return Uni.createFrom().failure(ex);
         }
 
-        LOG.debugf("Getting channel for service: %s", serviceName);
+        LOG.tracef("Getting channel for service: %s", serviceName);
 
         return serviceDiscoveryManager.ensureServiceDefined(serviceName)
                 .chain(ignored -> {
-                    LOG.debugf("Step 1: Service %s defined", serviceName);
+                    LOG.tracef("Step 1: Service %s defined", serviceName);
                     return serviceDiscoveryManager.getServiceInstances(serviceName);
                 })
                 .chain(instances -> {
-                    LOG.debugf("Step 2: Got %d instances for %s", instances.size(), serviceName);
+                    LOG.tracef("Step 2: Got %d instances for %s", instances.size(), serviceName);
                     return channelManager.getOrCreateChannel(serviceName, instances);
                 });
     }

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/ServiceDiscoveryManager.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/ServiceDiscoveryManager.java
@@ -103,7 +103,7 @@ public class ServiceDiscoveryManager {
         // First check if this service is already programmatically defined
         Optional<Service> existingService = Stork.getInstance().getServiceOptional(storkServiceName);
         if (existingService.isPresent()) {
-            LOG.debugf("Service %s already defined in Stork (programmatic)", storkServiceName);
+            LOG.tracef("Service %s already defined in Stork (programmatic)", storkServiceName);
             return Uni.createFrom().voidItem();
         }
 
@@ -260,7 +260,7 @@ public class ServiceDiscoveryManager {
                             LOG.warnf("No instances found for service: %s", serviceName);
                             metrics.recordServiceDiscovery(serviceName, true, 0);
                         } else {
-                            LOG.debugf("Found %d instances for service: %s", instances.size(), serviceName);
+                            LOG.tracef("Found %d instances for service: %s", instances.size(), serviceName);
                             metrics.recordServiceDiscovery(serviceName, true, instances.size());
                         }
                         return instances;


### PR DESCRIPTION
## Summary

Per-call log messages in the dynamic gRPC extension fire on every single RPC call. When any consumer enables DEBUG on `ai.pipestream.quarkus.dynamicgrpc`, the logs flood with thousands of identical \"Getting channel\" / \"Step 1/2\" / \"Returning channel\" lines per second. These are genuinely TRACE-level events — they describe the happy path of a cache hit during routine discovery.

Moved to TRACE:

- `DynamicGrpcClientFactory`: \"Getting channel for service\", \"Step 1: Service defined\", \"Step 2: Got N instances\"
- `ServiceDiscoveryManager`: \"Service X already defined in Stork\", \"Found N instances for service\"
- `ChannelManager`: \"Returning gRPC channel for service\" (cache hit path)

Left at DEBUG (once per service, not per call):

- Channel creation, TLS configuration, auth interceptor, shutdown, manual eviction

## Effect

With this change, enabling DEBUG on `ai.pipestream.quarkus.dynamicgrpc` in dev mode shows only meaningful setup events — channel creation, Stork service registration, discovery failures. Per-call tracing still available via TRACE for deep debugging.

## Test plan

- [x] Runtime module compiles and unit tests pass
- [x] Integration tests pass