### PR TITLE
chore: flatten pipestreamProtos gitRef to main in pipestream-service-registration

### DIFF
--- a/pipestream-service-registration/runtime/build.gradle
+++ b/pipestream-service-registration/runtime/build.gradle
@@ -22,8 +22,8 @@ tasks.matching { it.name == 'validateExtension' }.configureEach {
 pipestreamProtos {
     // git-proto-workspace clones the repo directly (no buf export / no BSR auth needed)
     sourceMode = 'git-proto-workspace'
-    gitRepo = System.getenv('PROTO_GIT_REPO') ?: "https://github.com/ai-pipestream/pipestream-protos.git"
-    gitRef = System.getenv('PROTO_GIT_REF') ?: "main"
+    gitRepo = "https://github.com/ai-pipestream/pipestream-protos.git"
+    gitRef = "main"
 
     modules {
         register("registration")


### PR DESCRIPTION
## Summary

Remove the `System.getenv('PROTO_GIT_REF') ?: "main"` indirection from `pipestream-service-registration/runtime/build.gradle` and pin directly to the HTTPS GitHub URL at `main`. The env-var override pattern was being used to pin to feature branches locally, but we now always consume from main via PRs.

## Test plan

- [x] `./gradlew :pipestream-service-registration:compileJava --rerun-tasks` — BUILD SUCCESSFUL
