### PR TITLE
test(dynamic-grpc): fix CI flake from Mutiny TimeoutException escaping awaitility

### DIFF
--- a/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/AuthDisabledTest.java
+++ b/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/AuthDisabledTest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 /**
  * Integration tests to verify behavior when auth is disabled.
@@ -129,17 +128,9 @@ class AuthDisabledTest {
 
     @Test
     void shouldNotAddAuthTokenWhenDisabled() {
-        // Wait for Consul registration
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(factory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
-                .await().atMost(Duration.ofSeconds(1)))
-                .as("Client should be discoverable")
-                .isNotNull();
-        });
-
         // Create client and make request
         var client = factory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
-            .await().atMost(Duration.ofSeconds(5));
+            .await().atMost(Duration.ofSeconds(10));
 
         HelloRequest request = HelloRequest.newBuilder()
             .setName("No Auth Test")

--- a/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/AuthTokenTest.java
+++ b/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/AuthTokenTest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 /**
  * Integration tests for authentication token functionality.
@@ -137,17 +136,9 @@ class AuthTokenTest {
 
     @Test
     void shouldAddAuthTokenToRequest() {
-        // Wait for Consul registration
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(factory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
-                .await().atMost(Duration.ofSeconds(1)))
-                .as("Client should be discoverable for auth test")
-                .isNotNull();
-        });
-
         // Create client and make request
         var client = factory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
-            .await().atMost(Duration.ofSeconds(5));
+            .await().atMost(Duration.ofSeconds(10));
 
         HelloRequest request = HelloRequest.newBuilder()
             .setName("Auth Test")
@@ -168,14 +159,6 @@ class AuthTokenTest {
 
     @Test
     void shouldIncludeTokenInMultipleRequests() {
-        // Wait for Consul registration
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(factory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
-                .await().atMost(Duration.ofSeconds(1)))
-                .as("Client should be discoverable")
-                .isNotNull();
-        });
-
         var client = factory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
             .await().atMost(Duration.ofSeconds(10));
 

--- a/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/ChannelLifecycleTest.java
+++ b/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/ChannelLifecycleTest.java
@@ -89,16 +89,9 @@ public class ChannelLifecycleTest {
     @DisplayName("Channel cache hit ratio should improve over time")
     void testCacheHitRatio() {
         consulRegistration.registerService(serviceName, serviceName + "-1", "127.0.0.1", lifecyclePort);
-        
-        // Wait for discovery
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(1)))
-                .as("Channel should be discoverable")
-                .isNotNull();
-        });
 
-        // First call - miss (creates channel)
-        clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(5));
+        // First call - miss (creates channel). Generous budget covers warmup.
+        clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(10));
 
         String stats1 = clientFactory.getCacheStats();
         LOG.infof("After 1 call: %s", stats1);
@@ -125,11 +118,7 @@ public class ChannelLifecycleTest {
         int initialCount = clientFactory.getActiveServiceCount();
 
         // Create a channel (wait for Consul discovery + cache population)
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(1)))
-                .as("Channel should be discoverable")
-                .isNotNull();
-        });
+        clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(10));
 
         int afterCreation = clientFactory.getActiveServiceCount();
         assertThat(afterCreation)
@@ -151,16 +140,9 @@ public class ChannelLifecycleTest {
     @DisplayName("Multiple evictions of same service should be safe")
     void testMultipleEvictions() {
         consulRegistration.registerService(serviceName, serviceName + "-1", "127.0.0.1", lifecyclePort);
-        
-        // Wait for discovery
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(1)))
-                .as("Channel should be discoverable")
-                .isNotNull();
-        });
 
         // Create channel
-        clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(5));
+        clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(10));
 
         // Evict multiple times - should not crash
         clientFactory.evictChannel(serviceName);
@@ -181,16 +163,9 @@ public class ChannelLifecycleTest {
         // Capture count BEFORE channel creation (randomized service not in cache yet)
         int initialCount = clientFactory.getActiveServiceCount();
 
-        // Wait for discovery
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(1)))
-                .as("Channel should be discoverable")
-                .isNotNull();
-        });
-
-        // Get Mutiny stub (should reuse cached channel)
+        // Get Mutiny stub (populates cache; generous budget covers discovery warmup)
         var mutinyStub = clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
-            .await().atMost(Duration.ofSeconds(5));
+            .await().atMost(Duration.ofSeconds(10));
 
         // Get raw channel again (should reuse cached channel)
         var channel = clientFactory.getChannel(serviceName)
@@ -221,14 +196,10 @@ public class ChannelLifecycleTest {
             consulRegistration.registerService(name, name + "-1", "127.0.0.1", lifecyclePort);
         }
 
-        // Wait for discovery and populate cache
+        // Populate cache (generous budget per service covers discovery warmup)
         for (int i = 0; i < 5; i++) {
             String name = serviceName + "-" + i;
-            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-                assertThat(clientFactory.getChannel(name).await().atMost(Duration.ofSeconds(1)))
-                    .as("Service " + name + " should be discoverable")
-                    .isNotNull();
-            });
+            clientFactory.getChannel(name).await().atMost(Duration.ofSeconds(10));
         }
 
         assertThat(clientFactory.getActiveServiceCount())
@@ -257,16 +228,10 @@ public class ChannelLifecycleTest {
     @DisplayName("Cache stats should provide useful debugging information")
     void testCacheStatsContent() {
         consulRegistration.registerService(serviceName, serviceName + "-1", "127.0.0.1", lifecyclePort);
-        
-        // Wait for discovery
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(1)))
-                .as("Channel should be discoverable")
-                .isNotNull();
-        });
 
-        // Make some calls
-        for (int i = 0; i < 5; i++) {
+        // First call takes the discovery hit; subsequent calls hit the cache.
+        clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(10));
+        for (int i = 0; i < 4; i++) {
             clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(3));
         }
 

--- a/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/DynamicGrpcEdgeCasesTest.java
+++ b/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/DynamicGrpcEdgeCasesTest.java
@@ -134,12 +134,10 @@ public class DynamicGrpcEdgeCasesTest {
         String id = serviceName + "-temp";
         consulRegistration.registerService(serviceName, id, "127.0.0.1", 9999);
         
-        // Verify it's discoverable
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(1)))
-                .as("Service should be discoverable after registration")
-                .isNotNull();
-        });
+        // Verify it's discoverable — generous budget covers initial warmup
+        assertThat(clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(10)))
+            .as("Service should be discoverable after registration")
+            .isNotNull();
 
         // Deregister it
         consulRegistration.deregisterService(id);
@@ -164,12 +162,8 @@ public class DynamicGrpcEdgeCasesTest {
         String id = serviceName + "-1-instance";
         consulRegistration.registerService(serviceName, id, "127.0.0.1", 9998);
         
-        // Wait for discovery
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(1)))
-                .as("Service should be discoverable for concurrent test")
-                .isNotNull();
-        });
+        // Warm up discovery + cache before concurrent test
+        clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(10));
 
         int initialCount = clientFactory.getActiveServiceCount();
 

--- a/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/DynamicGrpcPerformanceTest.java
+++ b/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/DynamicGrpcPerformanceTest.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 /**
  * Performance tests for GrpcClientFactory with real Consul.
@@ -57,13 +56,11 @@ public class DynamicGrpcPerformanceTest {
         String serviceId = serviceName + "-1";
 
         consulRegistration.registerService(serviceName, serviceId, "127.0.0.1", 9997);
-        
-        // Wait for discovery to be possible
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(1))).isNotNull();
-        });
 
-        // Measure time with cache likely populated
+        // Warm up discovery + cache so the measured call below is a genuine cache hit.
+        clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(10));
+
+        // Measure time on a cache-hot channel
         long start = System.nanoTime();
         clientFactory.getChannel(serviceName)
             .await().atMost(Duration.ofSeconds(5));
@@ -100,11 +97,9 @@ public class DynamicGrpcPerformanceTest {
         String serviceId = serviceName + "-1";
 
         consulRegistration.registerService(serviceName, serviceId, "127.0.0.1", 9996);
-        
-        // Wait for discovery
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(1))).isNotNull();
-        });
+
+        // Warm up discovery before the concurrent test
+        clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(10));
 
         int initialCount = clientFactory.getActiveServiceCount();
 
@@ -156,12 +151,10 @@ public class DynamicGrpcPerformanceTest {
             consulRegistration.registerService(serviceName, serviceId, "127.0.0.1", port);
         }
 
-        // Wait for all to be discoverable
+        // Populate cache for each (generous budget handles discovery warmup)
         for (int i = 0; i < 5; i++) {
             String serviceName = "multi-service-" + i;
-            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-                assertThat(clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(1))).isNotNull();
-            });
+            clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(10));
         }
 
         // Should have 5 new channels (one per service)
@@ -183,11 +176,9 @@ public class DynamicGrpcPerformanceTest {
         String serviceId = serviceName + "-1";
 
         consulRegistration.registerService(serviceName, serviceId, "127.0.0.1", 9995);
-        
-        // Wait for discovery
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(1))).isNotNull();
-        });
+
+        // Warm up discovery + cache
+        clientFactory.getChannel(serviceName).await().atMost(Duration.ofSeconds(10));
 
         int initialCount = clientFactory.getActiveServiceCount();
 

--- a/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/FailureRecoveryTest.java
+++ b/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/FailureRecoveryTest.java
@@ -11,6 +11,7 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -82,17 +83,9 @@ public class FailureRecoveryTest {
 
         consulRegistration.registerService(serviceName, serviceName + "-1", "127.0.0.1", port);
 
-        // Wait for service to be discoverable
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            var clientUni = clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub);
-            assertThat(clientUni.await().atMost(Duration.ofSeconds(1)))
-                .as("Initial client should be discoverable")
-                .isNotNull();
-        });
-
-        // Make a call
+        // Make a call (generous budget covers initial discovery warmup)
         var client = clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
-            .await().atMost(Duration.ofSeconds(5));
+            .await().atMost(Duration.ofSeconds(10));
         HelloReply response = client.sayHello(HelloRequest.newBuilder().setName("Before Crash").build())
             .await().atMost(Duration.ofSeconds(2));
         assertThat(response.getMessage())
@@ -125,16 +118,21 @@ public class FailureRecoveryTest {
             .start();
         consulRegistration.registerService(serviceName, serviceName + "-1", "127.0.0.1", port);
 
-        // Verify recovery
-        await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
-            var recoveredClient = clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
-                .await().atMost(Duration.ofSeconds(1));
-            HelloReply resp = recoveredClient.sayHello(HelloRequest.newBuilder().setName("After Crash").build())
-                .await().atMost(Duration.ofSeconds(2));
-            assertThat(resp.getMessage())
-                .as("Response after restart should be correct")
-                .isEqualTo("Hello After Crash");
-        });
+        // Verify recovery. awaitility is genuinely useful here: after the server
+        // restart, Stork needs to re-discover and the gRPC connection needs to
+        // re-establish — transient Mutiny TimeoutExceptions during polling are
+        // expected, so we tell awaitility to ignore that specific type.
+        await().atMost(Duration.ofSeconds(10))
+            .ignoreException(TimeoutException.class)
+            .untilAsserted(() -> {
+                var recoveredClient = clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
+                    .await().atMost(Duration.ofSeconds(1));
+                HelloReply resp = recoveredClient.sayHello(HelloRequest.newBuilder().setName("After Crash").build())
+                    .await().atMost(Duration.ofSeconds(2));
+                assertThat(resp.getMessage())
+                    .as("Response after restart should be correct")
+                    .isEqualTo("Hello After Crash");
+            });
 
         server.shutdownNow();
     }
@@ -156,13 +154,9 @@ public class FailureRecoveryTest {
         consulRegistration.registerService(serviceName, serviceName + "-1", "127.0.0.1", port1);
         consulRegistration.registerService(serviceName, serviceName + "-2", "127.0.0.1", port2);
 
-        // Wait for both to be up
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
-                .await().atMost(Duration.ofSeconds(1)))
-                .as("Client should be discoverable with multiple instances")
-                .isNotNull();
-        });
+        // Warm up discovery (generous budget covers initial Consul poll)
+        clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
+            .await().atMost(Duration.ofSeconds(10));
 
         // Kill one server
         server1.shutdownNow();
@@ -175,10 +169,11 @@ public class FailureRecoveryTest {
         Thread.sleep(2000);
 
         // Should still work via server2 — retry with eviction until Stork
-        // picks up the surviving instance
+        // picks up the surviving instance. Transient Mutiny TimeoutExceptions
+        // during polling are expected while discovery re-converges.
         await().atMost(Duration.ofSeconds(30))
             .pollInterval(Duration.ofMillis(500))
-            .ignoreExceptions()
+            .ignoreException(TimeoutException.class)
             .untilAsserted(() -> {
                 // Evict before each attempt so Stork re-discovers
                 clientFactory.evictChannel(serviceName);
@@ -209,15 +204,19 @@ public class FailureRecoveryTest {
         consulRegistration.deregisterService(serviceName + "-temp");
         consulRegistration.registerService(serviceName, serviceName + "-final", "127.0.0.1", port);
 
-        await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
-            var client = clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
-                .await().atMost(Duration.ofSeconds(1));
-            HelloReply resp = client.sayHello(HelloRequest.newBuilder().setName("Rapid").build())
-                .await().atMost(Duration.ofSeconds(2));
-            assertThat(resp.getMessage())
-                .as("Should work after rapid registration changes")
-                .isEqualTo("Hello Rapid");
-        });
+        // Poll until discovery stabilizes on the final registration.
+        // Transient Mutiny TimeoutExceptions during poll are expected.
+        await().atMost(Duration.ofSeconds(10))
+            .ignoreException(TimeoutException.class)
+            .untilAsserted(() -> {
+                var client = clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
+                    .await().atMost(Duration.ofSeconds(1));
+                HelloReply resp = client.sayHello(HelloRequest.newBuilder().setName("Rapid").build())
+                    .await().atMost(Duration.ofSeconds(2));
+                assertThat(resp.getMessage())
+                    .as("Should work after rapid registration changes")
+                    .isEqualTo("Hello Rapid");
+            });
 
         server.shutdownNow();
         consulRegistration.deregisterService(serviceName + "-final");
@@ -234,14 +233,10 @@ public class FailureRecoveryTest {
             .build().start();
 
         consulRegistration.registerService(serviceName, serviceName + "-1", "127.0.0.1", port);
-        
-        // Wait for up
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
-                .await().atMost(Duration.ofSeconds(1)))
-                .as("Should be discoverable while up")
-                .isNotNull();
-        });
+
+        // Warm up discovery
+        clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
+            .await().atMost(Duration.ofSeconds(10));
 
         // Shut down server and deregister
         server.shutdownNow();
@@ -287,16 +282,9 @@ public class FailureRecoveryTest {
 
         consulRegistration.registerService(serviceName, serviceName + "-1", "127.0.0.1", port);
 
-        // Wait for up
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
-                .await().atMost(Duration.ofSeconds(1)))
-                .as("Should be discoverable")
-                .isNotNull();
-        });
-
+        // Warm up discovery (generous budget covers the first Consul poll)
         var client = clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
-            .await().atMost(Duration.ofSeconds(5));
+            .await().atMost(Duration.ofSeconds(10));
 
         // Call should timeout
         assertThatThrownBy(() ->

--- a/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/MultipleServiceInstancesTest.java
+++ b/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/MultipleServiceInstancesTest.java
@@ -9,6 +9,7 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -114,13 +115,6 @@ public class MultipleServiceInstancesTest {
     @Test
     @DisplayName("Should discover all service instances")
     void testDiscoverAllInstances() {
-        // Wait for discovery to work
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub).await().atMost(Duration.ofSeconds(1)))
-                .as("Client should be discoverable with multiple instances")
-                .isNotNull();
-        });
-
         // The factory should be able to create a client (discovers at least one instance)
         var client = clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
             .await().atMost(Duration.ofSeconds(10));
@@ -145,13 +139,6 @@ public class MultipleServiceInstancesTest {
     @Test
     @DisplayName("Multiple requests should potentially hit different instances")
     void testLoadDistribution() {
-        // Wait for discovery
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub).await().atMost(Duration.ofSeconds(1)))
-                .as("Client should be discoverable for load distribution test")
-                .isNotNull();
-        });
-
         var client = clientFactory.getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
             .await().atMost(Duration.ofSeconds(10));
 
@@ -198,36 +185,35 @@ public class MultipleServiceInstancesTest {
         consulRegistration.registerService(ftServiceName, ftServiceName + "-1", "127.0.0.1", ftPort1);
         consulRegistration.registerService(ftServiceName, ftServiceName + "-2", "127.0.0.1", ftPort2);
 
-        // Wait for discovery
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            var c = clientFactory.getClient(ftServiceName, MutinyGreeterGrpc::newMutinyStub)
-                .await().atMost(Duration.ofSeconds(1));
-            HelloReply r = c.sayHello(HelloRequest.newBuilder().setName("Init").build())
-                .await().atMost(Duration.ofSeconds(2));
-            assertThat(r.getMessage()).contains("Hello");
-        });
+        // Warm up discovery and verify the initial round-trip works
+        var initClient = clientFactory.getClient(ftServiceName, MutinyGreeterGrpc::newMutinyStub)
+            .await().atMost(Duration.ofSeconds(10));
+        HelloReply initReply = initClient.sayHello(HelloRequest.newBuilder().setName("Init").build())
+            .await().atMost(Duration.ofSeconds(5));
+        assertThat(initReply.getMessage())
+            .as("Initial round-trip should work before failover test")
+            .contains("Hello");
 
         // Shut down one instance
         ftServer1.shutdownNow();
         consulRegistration.deregisterService(ftServiceName + "-1");
         clientFactory.evictChannel(ftServiceName);
 
-        // Service should still work via ftServer2 — get a fresh client after eviction
+        // Service should still work via ftServer2 — retry until Stork picks
+        // up the surviving instance. Transient Mutiny TimeoutExceptions during
+        // polling are expected while discovery converges on the survivor.
         await().atMost(Duration.ofSeconds(15))
             .pollInterval(Duration.ofMillis(500))
+            .ignoreException(TimeoutException.class)
             .untilAsserted(() -> {
-                try {
-                    var newClient = clientFactory.getClient(ftServiceName, MutinyGreeterGrpc::newMutinyStub)
-                        .await().atMost(Duration.ofSeconds(2));
-                    HelloReply reply = newClient.sayHello(HelloRequest.newBuilder().setName("After Shutdown").build())
-                        .await().atMost(Duration.ofSeconds(2));
-                    assertThat(reply.getMessage())
-                        .as("Should fall back to surviving instance")
-                        .contains("Hello");
-                } catch (Exception e) {
-                    clientFactory.evictChannel(ftServiceName);
-                    throw e;
-                }
+                clientFactory.evictChannel(ftServiceName);
+                var newClient = clientFactory.getClient(ftServiceName, MutinyGreeterGrpc::newMutinyStub)
+                    .await().atMost(Duration.ofSeconds(2));
+                HelloReply reply = newClient.sayHello(HelloRequest.newBuilder().setName("After Shutdown").build())
+                    .await().atMost(Duration.ofSeconds(2));
+                assertThat(reply.getMessage())
+                    .as("Should fall back to surviving instance")
+                    .contains("Hello");
             });
 
         // Cleanup

--- a/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/StressTest.java
+++ b/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/StressTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 /**
  * Stress tests for GrpcClientFactory under heavy load.
@@ -113,14 +112,11 @@ public class StressTest {
             consulRegistration.registerService(name, name + "-instance", "127.0.0.1", stressPorts.get(i));
         }
 
-        // Wait for all to be discoverable
+        // Warm up discovery for every service before the stress phase
         for (int i = 0; i < 10; i++) {
             String name = baseServiceName + "-" + i;
-            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-                assertThat(clientFactory.getClient(name, MutinyGreeterGrpc::newMutinyStub).await().atMost(Duration.ofSeconds(1)))
-                    .as("Service " + name + " should be discoverable")
-                    .isNotNull();
-            });
+            clientFactory.getClient(name, MutinyGreeterGrpc::newMutinyStub)
+                .await().atMost(Duration.ofSeconds(10));
         }
 
         ExecutorService executor = Executors.newFixedThreadPool(20);
@@ -175,12 +171,9 @@ public class StressTest {
         String name = baseServiceName + "-sustained";
         consulRegistration.registerService(name, name + "-instance", "127.0.0.1", stressPorts.get(0));
 
-        // Wait for discovery
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getClient(name, MutinyGreeterGrpc::newMutinyStub).await().atMost(Duration.ofSeconds(1)))
-                .as("Sustained load service should be discoverable")
-                .isNotNull();
-        });
+        // Warm up discovery before the sustained load phase
+        clientFactory.getClient(name, MutinyGreeterGrpc::newMutinyStub)
+            .await().atMost(Duration.ofSeconds(10));
 
         AtomicInteger successCount = new AtomicInteger(0);
         AtomicInteger failureCount = new AtomicInteger(0);
@@ -236,14 +229,11 @@ public class StressTest {
             consulRegistration.registerService(name, name + "-instance", "127.0.0.1", stressPorts.get(i));
         }
 
-        // Wait for all to be discoverable
+        // Warm up discovery for every service before rapid-switching phase
         for (int i = 0; i < 10; i++) {
             String name = baseServiceName + "-switch-" + i;
-            await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
-                assertThat(clientFactory.getClient(name, MutinyGreeterGrpc::newMutinyStub).await().atMost(Duration.ofSeconds(1)))
-                    .as("Service " + name + " should be discoverable for switching test")
-                    .isNotNull();
-            });
+            clientFactory.getClient(name, MutinyGreeterGrpc::newMutinyStub)
+                .await().atMost(Duration.ofSeconds(10));
         }
 
         AtomicInteger successCount = new AtomicInteger(0);
@@ -289,11 +279,9 @@ public class StressTest {
         String name = baseServiceName + "-memory";
         consulRegistration.registerService(name, name + "-instance", "127.0.0.1", stressPorts.get(0));
 
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(clientFactory.getClient(name, MutinyGreeterGrpc::newMutinyStub).await().atMost(Duration.ofSeconds(1)))
-                .as("Memory test service should be discoverable")
-                .isNotNull();
-        });
+        // Warm up discovery before the memory stability loop
+        clientFactory.getClient(name, MutinyGreeterGrpc::newMutinyStub)
+            .await().atMost(Duration.ofSeconds(10));
 
         int initialChannelCount = clientFactory.getActiveServiceCount();
 

--- a/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/base/DynamicGrpcClientFactoryTestBase.java
+++ b/quarkus-dynamic-grpc/integration-tests/src/test/java/ai/pipestream/quarkus/dynamicgrpc/base/DynamicGrpcClientFactoryTestBase.java
@@ -110,21 +110,11 @@ public abstract class DynamicGrpcClientFactoryTestBase {
 
     @Test
     void testClientCreationAndCall() {
-        registerServiceInConsul();
-
-        // Wait for Consul registration to propagate
-        await().atMost(Duration.ofSeconds(5))
-            .alias("Wait for service discovery")
-            .untilAsserted(() -> {
-                var clientUni = getFactory().getClient(serviceName, MutinyGreeterGrpc::newMutinyStub);
-                assertThat(clientUni.await().atMost(Duration.ofSeconds(1)))
-                    .as("Client should be discoverable in Stork")
-                    .isNotNull();
-            });
-
-        // Get a Mutiny client stub using the factory
         var client = getFactory().getClient(serviceName, MutinyGreeterGrpc::newMutinyStub)
-            .await().atMost(Duration.ofSeconds(5));
+            .await().atMost(Duration.ofSeconds(10));
+        assertThat(client)
+            .as("Client should be discoverable in Stork")
+            .isNotNull();
 
         // Make a real gRPC call
         HelloRequest request = HelloRequest.newBuilder()
@@ -144,17 +134,6 @@ public abstract class DynamicGrpcClientFactoryTestBase {
 
     @Test
     void testClientReuse() {
-        registerServiceInConsul();
-
-        // Wait for Consul registration to propagate
-        await().atMost(Duration.ofSeconds(5))
-            .alias("Wait for service discovery")
-            .untilAsserted(() -> {
-                assertThat(getFactory().getClient(serviceName, MutinyGreeterGrpc::newMutinyStub).await().atMost(Duration.ofSeconds(1)))
-                    .as("Client should be discoverable")
-                    .isNotNull();
-            });
-
         GrpcClientFactory factory = getFactory();
 
         // Request the same client twice - should use cached channel
@@ -180,12 +159,6 @@ public abstract class DynamicGrpcClientFactoryTestBase {
 
     @Test
     void testCacheStats() {
-        registerServiceInConsul();
-
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(getFactory().getClient(serviceName, MutinyGreeterGrpc::newMutinyStub).await().atMost(Duration.ofSeconds(1))).isNotNull();
-        });
-
         GrpcClientFactory factory = getFactory();
 
         // Make a call to populate cache
@@ -203,12 +176,6 @@ public abstract class DynamicGrpcClientFactoryTestBase {
 
     @Test
     void testChannelEviction() {
-        registerServiceInConsul();
-
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            assertThat(getFactory().getClient(serviceName, MutinyGreeterGrpc::newMutinyStub).await().atMost(Duration.ofSeconds(1))).isNotNull();
-        });
-
         GrpcClientFactory factory = getFactory();
 
         // Create a client to populate cache


### PR DESCRIPTION
## Summary

- Root cause: awaitility's `untilAsserted` only retries on `AssertionError`, but `io.smallrye.mutiny.TimeoutException` extends `RuntimeException`. On slow CI runners, the 1-second inner poll during Stork discovery warmup fired, the exception bypassed awaitility's retry loop, and the test failed immediately at `UniBlockingAwait.java:65` without the outer 5-second budget ever being used. Fast runners never hit the race because discovery finished inside the inner budget — which is why CI went red against passing local runs.
- Deleted every pointless `untilAsserted` wrapper that was just "wait for discovery" — the subsequent `.await().atMost(10s)` already awaits the same Uni, so one generous budget replaces awaitility + inner poll. Cleaner, single stack trace on failure, easier to debug.
- Kept awaitility for 4 genuine retry loops (crash/restart recovery, rapid re-registration, failover, partial failure) and added `.ignoreException(io.smallrye.mutiny.TimeoutException.class)` so transient Mutiny timeouts during polling get retried. **Other exceptions (`ServiceNotFoundException`, CDI errors, etc.) still propagate with real stack traces** — we are not ignoring all exceptions.
- Switched `FailureRecoveryTest.testPartialFailure` from `.ignoreExceptions()` (masks all bugs) to `.ignoreException(TimeoutException.class)` (surgical).
- Removed redundant `registerServiceInConsul()` calls from the 4 `DynamicGrpcClientFactoryTestBase` test bodies — the subclass `@BeforeEach` already registers, so every test was registering twice.

Net diff: **111 insertions, 258 deletions** across 9 files — mostly pure deletion of ceremonial awaitility scaffolding.

## Reference

- Failing run that motivated this: https://github.com/ai-pipestream/pipestream-platform/actions/runs/24379539105/job/71199952315
- `io.smallrye.mutiny.TimeoutException extends java.lang.RuntimeException` — confirmed via javap against mutiny-2.6.2.jar
- `org.awaitility.core.AssertionCondition` line 56-62: catches `AssertionError` for retry, any other `Throwable` goes to `CheckedExceptionRethrower.safeRethrow()`

## Test plan

- [x] `./gradlew :quarkus-dynamic-grpc-integration-tests:test` — 39/39 pass locally in 17s
- [ ] CI green on this PR (the whole point)
- [ ] No new flakes after this lands — watch the next few CI runs