### PR TITLE
chore(wiremock): bump pipestream-wiremock-server to 0.1.55

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ consul-client = "1.11.0"
 # ========================
 # External Pipestream Libraries (not part of this monorepo)
 # ========================
-pipestream-wiremock-server = "0.1.54"
+pipestream-wiremock-server = "0.1.55"
 
 # Gradle plugins
 axion-release = "1.21.1"

--- a/pipestream-server/runtime/src/main/java/ai/pipestream/server/constants/ContainerConstants.java
+++ b/pipestream-server/runtime/src/main/java/ai/pipestream/server/constants/ContainerConstants.java
@@ -17,7 +17,7 @@ public final class ContainerConstants {
     public static final class WireMock {
         private WireMock() {}
 
-        public static final String VERSION = "0.1.53";
+        public static final String VERSION = "0.1.55";
         public static final String IMAGE_PROPERTY = "pipestream.wiremock.image";
         public static final String IMAGE_ENV = "PIPESTREAM_WIREMOCK_IMAGE";
         public static final String IMAGE_ENV_FALLBACK = "WIREMOCK_IMAGE";

--- a/pipestream-test-support/README.md
+++ b/pipestream-test-support/README.md
@@ -33,4 +33,4 @@ You can override the WireMock container image at runtime:
 - Environment variable: `PIPESTREAM_WIREMOCK_IMAGE`
 - Environment variable (compat): `WIREMOCK_IMAGE`
 
-Default: `docker.io/pipestreamai/pipestream-wiremock-server:0.1.52`
+Default: `docker.io/pipestreamai/pipestream-wiremock-server:0.1.55`

--- a/pipestream-test-support/runtime/src/main/java/ai/pipestream/test/support/TestContainerConstants.java
+++ b/pipestream-test-support/runtime/src/main/java/ai/pipestream/test/support/TestContainerConstants.java
@@ -16,7 +16,7 @@ public final class TestContainerConstants {
     public static final class WireMock {
         private WireMock() {}
 
-        public static final String VERSION = "0.1.53";
+        public static final String VERSION = "0.1.55";
         public static final String IMAGE_PROPERTY = "pipestream.wiremock.image";
         public static final String IMAGE_ENV = "PIPESTREAM_WIREMOCK_IMAGE";
         public static final String IMAGE_ENV_FALLBACK = "WIREMOCK_IMAGE";


### PR DESCRIPTION
## Summary

Four stale version references bumped to **0.1.55** after the `pipestream-wiremock-server` release that includes the three semantic pipeline step mocks from [ai-pipestream/pipestream-wiremock-server#71](https://github.com/ai-pipestream/pipestream-wiremock-server/pull/71) (\`ChunkerStepMock\`, \`EmbedderStepMock\`, \`SemanticGraphStepMock\`, \`SemanticPipelineShowcaseTest\`).

| File | Before | After |
|---|---|---|
| \`gradle/libs.versions.toml:72\` | 0.1.54 | 0.1.55 |
| \`pipestream-test-support/runtime/src/main/java/ai/pipestream/test/support/TestContainerConstants.java:19\` | 0.1.53 | 0.1.55 |
| \`pipestream-server/runtime/src/main/java/ai/pipestream/server/constants/ContainerConstants.java:20\` | 0.1.53 | 0.1.55 |
| \`pipestream-test-support/README.md:36\` | 0.1.52 | 0.1.55 |

\`build/docs/javadoc/constant-values.html\` is a build artifact and will regenerate on the next \`:javadoc\` task — not edited manually.

## Why now

The Phase 3 refactor agents (R1 chunker, R2 embedder, R3 semantic-graph) are about to be dispatched. Each R-phase module will spin up \`pipestream-wiremock-server\` as a testcontainer via \`pipestream-test-support\`'s default container image, so the test-support jar needs to point at a container that actually contains the semantic-pipeline step mocks. 0.1.55 is the first release that has them.

## Test plan

- [x] \`./gradlew :pipestream-test-support:compileJava :pipestream-server:compileJava\` — BUILD SUCCESSFUL.
- [x] Grep verified: zero remaining \`0.1.5[0-4]\` references under source + config trees (excluding \`build/\`, \`.gradle/\`, and \`CHANGELOG\`).
- [x] All four updated files show \`0.1.55\`.
- [ ] CI green.

## Related

- \`ai-pipestream/pipestream-wiremock-server#71\` — semantic pipeline step mocks (merged, released as 0.1.55).
- \`ai-pipestream/pipestream-platform#51\` — \`SemanticPipelineInvariants\` (merged).
- \`ai-pipestream/pipestream-protos#37\` — ROLLOUT.md / PLAN.md / DESIGN.md §14 (merged).