### PR TITLE
feat(devservices): env-detecting djl-serving bootstrap for process-compose

### DIFF
--- a/pipestream-quarkus-devservices/runtime/src/main/resources/process-compose.env.example
+++ b/pipestream-quarkus-devservices/runtime/src/main/resources/process-compose.env.example
@@ -19,6 +19,10 @@ PC_PORT_NUM=8765
 # Infra ports exposed on host.
 #CONSUL_PORT=8500
 
+# Local djl-serving settings (used by dev-djl-serving / start-dev-djl.sh).
+#DJL_SERVING_HOST_PORT=8090
+#DJL_SERVING_CONTAINER_NAME=pipeline-djl-serving
+
 # Quarkus HTTP+gRPC port for each service.
 #PLATFORM_REGISTRATION_HTTP_PORT=18101
 #ACCOUNT_SERVICE_HTTP_PORT=18105

--- a/pipestream-quarkus-devservices/runtime/src/main/resources/process-compose.yaml
+++ b/pipestream-quarkus-devservices/runtime/src/main/resources/process-compose.yaml
@@ -26,6 +26,31 @@ processes:
     availability:
       restart: "no"
 
+  # Starts a local djl-serving container sized for the detected host
+  # (Linux+NVIDIA → GPU, Linux-CPU or other → CPU, macOS stubbed).
+  # module-embedder depends on this being healthy before it launches.
+  dev-djl-serving:
+    command: ${HOME}/.pipeline/dev/start-dev-djl.sh
+    is_daemon: true
+    shutdown:
+      command: docker rm -f ${DJL_SERVING_CONTAINER_NAME:-pipeline-djl-serving}
+      timeout_seconds: 30
+    depends_on:
+      dev-services:
+        condition: process_healthy
+    readiness_probe:
+      exec:
+        command: >
+          test "$(docker inspect --format '{{.State.Health.Status}}'
+          ${DJL_SERVING_CONTAINER_NAME:-pipeline-djl-serving} 2>/dev/null)" = "healthy"
+      initial_delay_seconds: 10
+      period_seconds: 5
+      timeout_seconds: 10
+      success_threshold: 1
+      failure_threshold: 120
+    availability:
+      restart: "no"
+
   platform-registration:
     command: quarkus dev
     working_dir: ${CORE_SERVICES_DIR}/platform-registration-service
@@ -304,11 +329,14 @@ processes:
 
   # module-embedder uses a nested working_dir because the outer directory is a
   # multi-project gradle build containing quarkus-djl-embeddings subprojects.
+  # Depends on dev-djl-serving so it has a backend to register models against.
   module-embedder:
     command: quarkus dev
     working_dir: ${MODULES_DIR}/module-embedder/module-embedder
     depends_on:
       platform-registration:
+        condition: process_healthy
+      dev-djl-serving:
         condition: process_healthy
     readiness_probe:
       http_get:

--- a/pipestream-quarkus-devservices/runtime/src/main/resources/start-dev-djl.sh
+++ b/pipestream-quarkus-devservices/runtime/src/main/resources/start-dev-djl.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# start-dev-djl.sh — bring up a local djl-serving container for module-embedder.
+#
+# Detects the host environment and picks the right DJL Serving image variant.
+# Idempotent: if pipeline-djl-serving is already running healthy, no-op.
+# Joins the shared pipeline bridge so other containers can reach djl-serving
+# by hostname; host-side apps reach it via localhost:${DJL_SERVING_HOST_PORT}.
+
+set -u
+
+CONTAINER_NAME="${DJL_SERVING_CONTAINER_NAME:-pipeline-djl-serving}"
+HOST_PORT="${DJL_SERVING_HOST_PORT:-8090}"
+NETWORK="${PIPELINE_NETWORK:-pipeline-shared-devservices_pipeline-test-network}"
+
+already_healthy() {
+  [ "$(docker inspect --format '{{.State.Health.Status}}' "$CONTAINER_NAME" 2>/dev/null)" = "healthy" ]
+}
+
+if already_healthy; then
+  echo "djl-serving: $CONTAINER_NAME is already healthy on localhost:$HOST_PORT — nothing to do"
+  exit 0
+fi
+
+# Clear out any stopped / unhealthy container of the same name so docker run
+# below doesn't fail with a name conflict.
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+
+# ---- Environment detection ----
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+IMAGE=""
+EXTRA_ARGS=()
+
+case "$OS" in
+  Linux)
+    if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then
+      IMAGE="deepjavalibrary/djl-serving:latest-pytorch-gpu"
+      EXTRA_ARGS+=(--gpus all)
+      echo "djl-serving: detected Linux + NVIDIA GPU → $IMAGE"
+    else
+      # Intel integrated graphics → OpenVINO (deferred; see roadmap).
+      # For now, fall through to CPU.
+      IMAGE="deepjavalibrary/djl-serving:latest"
+      echo "djl-serving: detected Linux, no NVIDIA GPU → CPU $IMAGE"
+      echo "djl-serving: TODO: OpenVINO variant for Intel integrated graphics is not implemented yet"
+    fi
+    ;;
+  Darwin)
+    # Not validated on Apple Silicon yet. Exit with a clear message so users
+    # hit a loud failure rather than a mystery-crashing container.
+    echo "djl-serving: macOS ($ARCH) path is not implemented yet. See TODO in start-dev-djl.sh" >&2
+    echo "djl-serving: planned — test latest CPU image on arm64, fall back to python mode if needed" >&2
+    exit 2
+    ;;
+  *)
+    echo "djl-serving: unsupported OS '$OS'" >&2
+    exit 2
+    ;;
+esac
+
+echo "djl-serving: pulling $IMAGE (first run may take a few minutes) ..."
+docker pull "$IMAGE" >/dev/null
+
+echo "djl-serving: starting $CONTAINER_NAME on localhost:$HOST_PORT"
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  --hostname djl-serving \
+  --network "$NETWORK" \
+  -p "${HOST_PORT}:8080" \
+  --health-cmd='curl -f http://localhost:8080/ping || exit 1' \
+  --health-interval=10s \
+  --health-timeout=5s \
+  --health-retries=5 \
+  --health-start-period=90s \
+  "${EXTRA_ARGS[@]}" \
+  "$IMAGE" >/dev/null
+
+echo "djl-serving: started. Register models via POST /models — see module-embedder/ADDING-MODELS.md"
+echo "djl-serving: host URL → http://localhost:$HOST_PORT"
+echo "djl-serving: bridge URL (for containers on $NETWORK) → http://djl-serving:8080"


### PR DESCRIPTION
## Summary

Adds a local djl-serving startup path so `module-embedder` (and anything else that wants embeddings) has a backend under process-compose orchestration without depending on the remote krick-1 box.

## New file: `start-dev-djl.sh`

Idempotent bootstrap invoked by the `dev-djl-serving` process. Detects the host environment and picks the right image variant:

| Environment | Image | Notes |
|---|---|---|
| Linux + NVIDIA GPU | `deepjavalibrary/djl-serving:latest-pytorch-gpu` | `--gpus all` |
| Linux, no NVIDIA | `deepjavalibrary/djl-serving:latest` | CPU |
| macOS | — | exits 2 with TODO message; not implemented yet |
| Other | — | hard error |

The container joins the shared pipeline bridge so other containers can reach it as `djl-serving:8080`. Host apps reach it via `localhost:${DJL_SERVING_HOST_PORT:-8090}`. Docker healthcheck curls `/ping`.

**OpenVINO variant for Intel integrated graphics is a follow-up** — noted in the script with a clear TODO.

## process-compose changes

- New `dev-djl-serving` process gated on `dev-services` healthy.
- `module-embedder` now also depends on `dev-djl-serving` healthy — it won't launch until the DJL container reports healthy.

## env.example

Documents `DJL_SERVING_HOST_PORT` and `DJL_SERVING_CONTAINER_NAME` overrides.

## Test plan

- [ ] On this machine (Linux + NVIDIA + AMD CPU): `process-compose up` brings dev-djl-serving to Ready, module-embedder starts and points at `localhost:8090`.
- [ ] Register `minilm` via `POST /models` (see `module-embedder/ADDING-MODELS.md`) — one-time step per container.
- [ ] macOS path — deferred until tested on hardware.
- [ ] OpenVINO path — deferred (Intel integrated graphics).