### PR TITLE
fix(dev-djl): use valid DJL Serving image tags

### DIFF
--- a/pipestream-quarkus-devservices/runtime/src/main/resources/process-compose.env.example
+++ b/pipestream-quarkus-devservices/runtime/src/main/resources/process-compose.env.example
@@ -22,6 +22,7 @@ PC_PORT_NUM=8765
 # Local djl-serving settings (used by dev-djl-serving / start-dev-djl.sh).
 #DJL_SERVING_HOST_PORT=8090
 #DJL_SERVING_CONTAINER_NAME=pipeline-djl-serving
+#DJL_SERVING_VERSION=0.36.0                # picks {version}-pytorch-gpu or {version}-cpu
 
 # Quarkus HTTP+gRPC port for each service.
 #PLATFORM_REGISTRATION_HTTP_PORT=18101

--- a/pipestream-quarkus-devservices/runtime/src/main/resources/start-dev-djl.sh
+++ b/pipestream-quarkus-devservices/runtime/src/main/resources/start-dev-djl.sh
@@ -6,11 +6,16 @@
 # Joins the shared pipeline bridge so other containers can reach djl-serving
 # by hostname; host-side apps reach it via localhost:${DJL_SERVING_HOST_PORT}.
 
-set -u
+set -eu
 
 CONTAINER_NAME="${DJL_SERVING_CONTAINER_NAME:-pipeline-djl-serving}"
 HOST_PORT="${DJL_SERVING_HOST_PORT:-8090}"
 NETWORK="${PIPELINE_NETWORK:-pipeline-shared-devservices_pipeline-test-network}"
+
+# DJL Serving does not publish a rolling `pytorch-gpu` tag — only versioned
+# ones (e.g. 0.36.0-pytorch-gpu). Pin a known-good release and let the user
+# override for upgrades.
+DJL_VERSION="${DJL_SERVING_VERSION:-0.36.0}"
 
 already_healthy() {
   [ "$(docker inspect --format '{{.State.Health.Status}}' "$CONTAINER_NAME" 2>/dev/null)" = "healthy" ]
@@ -35,13 +40,13 @@ EXTRA_ARGS=()
 case "$OS" in
   Linux)
     if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then
-      IMAGE="deepjavalibrary/djl-serving:latest-pytorch-gpu"
+      IMAGE="deepjavalibrary/djl-serving:${DJL_VERSION}-pytorch-gpu"
       EXTRA_ARGS+=(--gpus all)
       echo "djl-serving: detected Linux + NVIDIA GPU → $IMAGE"
     else
       # Intel integrated graphics → OpenVINO (deferred; see roadmap).
       # For now, fall through to CPU.
-      IMAGE="deepjavalibrary/djl-serving:latest"
+      IMAGE="deepjavalibrary/djl-serving:${DJL_VERSION}-cpu"
       echo "djl-serving: detected Linux, no NVIDIA GPU → CPU $IMAGE"
       echo "djl-serving: TODO: OpenVINO variant for Intel integrated graphics is not implemented yet"
     fi
@@ -60,7 +65,12 @@ case "$OS" in
 esac
 
 echo "djl-serving: pulling $IMAGE (first run may take a few minutes) ..."
-docker pull "$IMAGE" >/dev/null
+if ! docker pull "$IMAGE"; then
+  echo "djl-serving: docker pull failed for $IMAGE — aborting" >&2
+  echo "djl-serving: check the tag exists at https://hub.docker.com/r/deepjavalibrary/djl-serving/tags" >&2
+  echo "djl-serving: override the version with DJL_SERVING_VERSION=<version>" >&2
+  exit 1
+fi
 
 echo "djl-serving: starting $CONTAINER_NAME on localhost:$HOST_PORT"
 docker run -d \


### PR DESCRIPTION
## Bug

`start-dev-djl.sh` pulled `deepjavalibrary/djl-serving:latest-pytorch-gpu`, which does not exist on Docker Hub — the registry only has versioned GPU variants (`{version}-pytorch-gpu`). The pull silently failed and `docker run` followed with `Unable to find image`. Observed on Linux + NVIDIA.

## Fix

- Pin a known-good version (`DJL_VERSION=0.36.0`), overridable via `DJL_SERVING_VERSION` env var.
- GPU tag becomes `${version}-pytorch-gpu`; CPU becomes `${version}-cpu` (also a valid published tag).
- Add `set -e` and an explicit `docker pull` check so missing tags / registry hiccups fail loudly instead of silently cascading into a `docker run` failure.
- Document `DJL_SERVING_VERSION` in `process-compose.env.example`.

## Test plan

- [x] `docker manifest inspect deepjavalibrary/djl-serving:0.36.0-pytorch-gpu` returns a manifest — tag exists.
- [ ] On this machine (Linux + NVIDIA): `process-compose` brings `dev-djl-serving` to Ready and `module-embedder` starts.