### PR TITLE
feat(dev-djl): register e2e test models; log_location on dev-djl-serving

### DIFF
--- a/pipestream-quarkus-devservices/runtime/src/main/resources/process-compose.env.example
+++ b/pipestream-quarkus-devservices/runtime/src/main/resources/process-compose.env.example
@@ -24,6 +24,10 @@ PC_PORT_NUM=8765
 #DJL_SERVING_CONTAINER_NAME=pipeline-djl-serving
 #DJL_SERVING_VERSION=0.36.0                # picks {version}-pytorch-gpu or {version}-cpu
 
+# Space-separated list of <serving-name>:<huggingface-id> entries. Default
+# covers the two models used by module-embedder's e2e fixture-dump tests.
+#DJL_E2E_MODELS="minilm:sentence-transformers/all-MiniLM-L6-v2 paraphrase_MiniLM_L3_v2:sentence-transformers/paraphrase-MiniLM-L3-v2"
+
 # Quarkus HTTP+gRPC port for each service.
 #PLATFORM_REGISTRATION_HTTP_PORT=18101
 #ACCOUNT_SERVICE_HTTP_PORT=18105

--- a/pipestream-quarkus-devservices/runtime/src/main/resources/process-compose.yaml
+++ b/pipestream-quarkus-devservices/runtime/src/main/resources/process-compose.yaml
@@ -28,7 +28,6 @@ processes:
 
   # Starts a local djl-serving container sized for the detected host
   # (Linux+NVIDIA → GPU, Linux-CPU or other → CPU, macOS stubbed).
-  # module-embedder depends on this being healthy before it launches.
   dev-djl-serving:
     command: ${HOME}/.pipeline/dev/start-dev-djl.sh
     is_daemon: true
@@ -50,6 +49,19 @@ processes:
       failure_threshold: 120
     availability:
       restart: "no"
+    log_location: ${HOME}/.pipeline/dev/logs/dev-djl-serving.log
+
+  # One-shot: register the embedder e2e test models against the running
+  # djl-serving. Exits 0 once all configured models are loaded.
+  # module-embedder waits for this via process_completed_successfully.
+  dev-djl-models:
+    command: ${HOME}/.pipeline/dev/register-dev-djl-models.sh
+    depends_on:
+      dev-djl-serving:
+        condition: process_healthy
+    availability:
+      restart: "no"
+    log_location: ${HOME}/.pipeline/dev/logs/dev-djl-models.log
 
   platform-registration:
     command: quarkus dev
@@ -329,15 +341,16 @@ processes:
 
   # module-embedder uses a nested working_dir because the outer directory is a
   # multi-project gradle build containing quarkus-djl-embeddings subprojects.
-  # Depends on dev-djl-serving so it has a backend to register models against.
+  # Waits for dev-djl-models to finish so the embedder has a backend AND the
+  # expected e2e models already loaded.
   module-embedder:
     command: quarkus dev
     working_dir: ${MODULES_DIR}/module-embedder/module-embedder
     depends_on:
       platform-registration:
         condition: process_healthy
-      dev-djl-serving:
-        condition: process_healthy
+      dev-djl-models:
+        condition: process_completed_successfully
     readiness_probe:
       http_get:
         host: localhost

--- a/pipestream-quarkus-devservices/runtime/src/main/resources/register-dev-djl-models.sh
+++ b/pipestream-quarkus-devservices/runtime/src/main/resources/register-dev-djl-models.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# register-dev-djl-models.sh — register the embedder e2e test models against
+# the local djl-serving container.
+#
+# Idempotent. Skips models that are already loaded. Blocks on the target
+# djl-serving being reachable so it can be chained as a process-compose
+# dependency after dev-djl-serving.
+#
+# Override the set of models with DJL_E2E_MODELS — space-separated list of
+# entries in the form  <serving-name>:<huggingface-identifier>.
+#
+# Defaults match the two models consumed by module-embedder's e2e fixture
+# dump: minilm and paraphrase_MiniLM_L3_v2.
+
+set -eu
+
+HOST_PORT="${DJL_SERVING_HOST_PORT:-8090}"
+DJL_URL="${DJL_SERVING_URL:-http://localhost:${HOST_PORT}}"
+
+DEFAULT_MODELS=(
+  "minilm:sentence-transformers/all-MiniLM-L6-v2"
+  "paraphrase_MiniLM_L3_v2:sentence-transformers/paraphrase-MiniLM-L3-v2"
+)
+
+if [ -n "${DJL_E2E_MODELS:-}" ]; then
+  read -r -a MODELS <<< "$DJL_E2E_MODELS"
+else
+  MODELS=("${DEFAULT_MODELS[@]}")
+fi
+
+wait_for_djl() {
+  local deadline
+  deadline=$(( $(date +%s) + 300 ))   # 5 min max — first-time image pull + JVM boot
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if curl -fsS "$DJL_URL/ping" >/dev/null 2>&1; then return 0; fi
+    sleep 2
+  done
+  echo "djl-models: gave up waiting for $DJL_URL/ping after 5 minutes" >&2
+  return 1
+}
+
+echo "djl-models: waiting for $DJL_URL/ping ..."
+wait_for_djl
+echo "djl-models: djl-serving reachable"
+
+registered_count=0
+skipped_count=0
+
+for entry in "${MODELS[@]}"; do
+  serving_name="${entry%%:*}"
+  hf_id="${entry#*:}"
+
+  if curl -fsS "$DJL_URL/models/$serving_name" >/dev/null 2>&1; then
+    echo "djl-models: $serving_name already registered — skipping"
+    skipped_count=$((skipped_count + 1))
+    continue
+  fi
+
+  djl_url="djl://ai.djl.huggingface.pytorch/$hf_id"
+  encoded=$(python3 -c "from urllib.parse import quote; import sys; print(quote(sys.argv[1], safe=''))" "$djl_url")
+
+  echo "djl-models: registering $serving_name ← $djl_url ..."
+  if ! curl -fsS -X POST "$DJL_URL/models?url=$encoded&model_name=$serving_name&engine=PyTorch&synchronous=true"; then
+    echo "djl-models: registration of $serving_name FAILED — aborting" >&2
+    exit 1
+  fi
+  echo
+  registered_count=$((registered_count + 1))
+done
+
+echo "djl-models: done. registered=$registered_count skipped=$skipped_count total=${#MODELS[@]}"


### PR DESCRIPTION
## Summary

Chains a model-registration step after the djl-serving container starts so module-embedder comes up against a backend that already serves the two models the e2e fixture-dump tests consume.

## New file

**`register-dev-djl-models.sh`** — idempotent bootstrap:
- Polls `GET /ping` on `http://localhost:${DJL_SERVING_HOST_PORT:-8090}` for up to 5 min.
- For each entry in `${DJL_E2E_MODELS}` (space-separated `<serving-name>:<hf-id>` pairs, default: `minilm` + `paraphrase_MiniLM_L3_v2`):
  - Skips if `GET /models/${serving-name}` already returns 200.
  - Otherwise POSTs `djl://ai.djl.huggingface.pytorch/${hf-id}` with `engine=PyTorch&synchronous=true`.
- Fails loudly on any registration error.

## process-compose changes

- New `dev-djl-models` process runs the script. Gated on `dev-djl-serving` healthy.
- `module-embedder` now depends on `dev-djl-models` `process_completed_successfully` instead of `dev-djl-serving` `process_healthy` — the embedder waits until models are loaded.
- Added `log_location` to `dev-djl-serving` (was missing — its logs only showed in the TUI).

## env.example

Documents `DJL_E2E_MODELS` override.

## Test plan

- [ ] Full `process-compose down && up` on this (Linux + NVIDIA) machine — dev-djl-serving pulls & starts, dev-djl-models registers both defaults, module-embedder boots green.
- [ ] Idempotent re-run: `process-compose process restart dev-djl-models` — skips both models with 'already registered'.
- [ ] Macos/OpenVINO paths unaffected (still stubbed).