### PR TITLE
fix(dev-djl): readiness probe as script to avoid process-compose + Go-template collision

### DIFF
--- a/pipestream-quarkus-devservices/runtime/src/main/resources/check-djl-healthy.sh
+++ b/pipestream-quarkus-devservices/runtime/src/main/resources/check-djl-healthy.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# check-djl-healthy.sh — exits 0 when the local djl-serving container
+# reports Docker health status "healthy", non-zero otherwise. Used as the
+# readiness probe for the dev-djl-serving process in process-compose.yaml.
+#
+# Kept as a dedicated script (rather than an inline exec.command in the
+# yaml) because process-compose's interpolation collides with Docker's
+# Go-template syntax {{.State.Health.Status}}.
+
+set -u
+
+CONTAINER="${DJL_SERVING_CONTAINER_NAME:-pipeline-djl-serving}"
+
+status=$(docker inspect --format '{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null || true)
+
+if [ "$status" = "healthy" ]; then
+  exit 0
+fi
+
+echo "djl-serving: $CONTAINER status=${status:-missing}" >&2
+exit 1

--- a/pipestream-quarkus-devservices/runtime/src/main/resources/process-compose.yaml
+++ b/pipestream-quarkus-devservices/runtime/src/main/resources/process-compose.yaml
@@ -39,9 +39,7 @@ processes:
         condition: process_healthy
     readiness_probe:
       exec:
-        command: >
-          test "$(docker inspect --format '{{.State.Health.Status}}'
-          ${DJL_SERVING_CONTAINER_NAME:-pipeline-djl-serving} 2>/dev/null)" = "healthy"
+        command: ${HOME}/.pipeline/dev/check-djl-healthy.sh
       initial_delay_seconds: 10
       period_seconds: 5
       timeout_seconds: 10


### PR DESCRIPTION
## Bug

`dev-djl-serving` stuck at `Not Ready` even when the container's Docker healthcheck reports `healthy`. The container *is* up and DJL Serving *does* serve `/ping` — the problem is that process-compose's own variable interpolation mangles the Docker Go-template tokens (`{{.State.Health.Status}}`) in the inline probe command, so the `test "$(docker inspect ...)" = "healthy"` comparison never sees `healthy`.

## Fix

Same pattern as `check-infra-healthy.sh` — extract the probe to a dedicated shell script `check-djl-healthy.sh` so the Go-template string is quoted safely inside bash and out of process-compose's interpolation path. The probe `exec.command` now just points at the script.

## Test plan

- [x] `docker inspect --format '{{.State.Health.Status}}' pipeline-djl-serving` returns `healthy` on the live running container, confirming the health gate itself works — this is purely a process-compose interop fix.
- [ ] On next `process-compose` restart, `dev-djl-serving` flips to `Ready` and `module-embedder` unblocks.