### PR TITLE
fix(dev-djl): start dev-djl-serving in parallel with dev-services

### DIFF
--- a/pipestream-quarkus-devservices/runtime/src/main/resources/process-compose.yaml
+++ b/pipestream-quarkus-devservices/runtime/src/main/resources/process-compose.yaml
@@ -28,15 +28,14 @@ processes:
 
   # Starts a local djl-serving container sized for the detected host
   # (Linux+NVIDIA → GPU, Linux-CPU or other → CPU, macOS stubbed).
+  # No dependency on dev-services: djl-serving only needs Docker, and image
+  # pulls / model registration run in parallel with infra bring-up.
   dev-djl-serving:
     command: ${HOME}/.pipeline/dev/start-dev-djl.sh
     is_daemon: true
     shutdown:
       command: docker rm -f ${DJL_SERVING_CONTAINER_NAME:-pipeline-djl-serving}
       timeout_seconds: 30
-    depends_on:
-      dev-services:
-        condition: process_healthy
     readiness_probe:
       exec:
         command: ${HOME}/.pipeline/dev/check-djl-healthy.sh


### PR DESCRIPTION
## Change

Drops the `depends_on: dev-services (process_healthy)` edge from `dev-djl-serving`.

## Why

The two have no runtime coupling — djl-serving only needs the Docker daemon, not Consul/Kafka/Postgres/Apicurio. The GPU image pull (multi-GB, minutes on first run) was serialized behind infra bring-up for no reason. Letting them race shaves wall-time off a cold `process-compose up`.

`module-embedder` still waits for `dev-djl-models process_completed_successfully`, which transitively requires djl-serving healthy, so the ordering that matters is preserved.

## Test plan

- [ ] `process-compose down && up` on this machine — observe both dev-services and dev-djl-serving transition to Running immediately, with neither waiting on the other.