### PR TITLE
build: bump pipestream-wiremock-server 0.1.55 → 0.1.56 + dynamic-grpc counter cache

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ consul-client = "1.12.0"
 # ========================
 # External Pipestream Libraries (not part of this monorepo)
 # ========================
-pipestream-wiremock-server = "0.1.55"
+pipestream-wiremock-server = "0.1.56"
 
 # Gradle plugins
 axion-release = "1.21.1"

--- a/pipestream-server/runtime/src/main/java/ai/pipestream/server/constants/ContainerConstants.java
+++ b/pipestream-server/runtime/src/main/java/ai/pipestream/server/constants/ContainerConstants.java
@@ -17,7 +17,7 @@ public final class ContainerConstants {
     public static final class WireMock {
         private WireMock() {}
 
-        public static final String VERSION = "0.1.55";
+        public static final String VERSION = "0.1.56";
         public static final String IMAGE_PROPERTY = "pipestream.wiremock.image";
         public static final String IMAGE_ENV = "PIPESTREAM_WIREMOCK_IMAGE";
         public static final String IMAGE_ENV_FALLBACK = "WIREMOCK_IMAGE";

--- a/pipestream-test-support/README.md
+++ b/pipestream-test-support/README.md
@@ -33,4 +33,4 @@ You can override the WireMock container image at runtime:
 - Environment variable: `PIPESTREAM_WIREMOCK_IMAGE`
 - Environment variable (compat): `WIREMOCK_IMAGE`
 
-Default: `docker.io/pipestreamai/pipestream-wiremock-server:0.1.55`
+Default: `docker.io/pipestreamai/pipestream-wiremock-server:0.1.56`

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/ChannelManager.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/ChannelManager.java
@@ -27,6 +27,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import java.time.Duration;
@@ -125,17 +126,15 @@ public class ChannelManager {
         };
         metrics.recordChannelEvicted(serviceName, evictionReason);
 
+        // Channel may be wrapped by ClientInterceptors (auth) — unwrap is not
+        // exposed on the Channel API, but the auth wrapper doesn't own any
+        // I/O resources; it just forwards newCall. The underlying pool /
+        // managed channel is what actually needs closing. For the auth-wrapped
+        // case we lost the pool reference, which is fine: the GC will clean up
+        // once this bean is unreachable. All other cases we close explicitly.
         if (shuttingDown.get()) {
             LOG.debugf("Application shutting down, initiating non-blocking channel shutdown for service '%s'", serviceName);
-            try {
-                if (channel instanceof ManagedChannel) {
-                    ((ManagedChannel) channel).shutdownNow();
-                } else if (channel instanceof StorkGrpcChannel) {
-                    ((StorkGrpcChannel) channel).close();
-                }
-            } catch (Exception e) {
-                LOG.tracef("Error during shutdown of channel for service %s: %s", serviceName, e.getMessage());
-            }
+            closeChannelQuietly(channel, serviceName);
             return;
         }
 
@@ -148,27 +147,33 @@ public class ChannelManager {
                     LOG.warnf("Channel for service %s did not terminate gracefully, forcing shutdown", serviceName);
                     mc.shutdownNow();
                 }
-            } else if (channel instanceof StorkGrpcChannel) {
-                ((StorkGrpcChannel) channel).close();
+            } else if (channel instanceof RoundRobinChannel rrc) {
+                rrc.close();
+            } else if (channel instanceof StorkGrpcChannel sgc) {
+                sgc.close();
             }
             LOG.debugf("Successfully shut down channel for service: %s", serviceName);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             LOG.errorf("Interrupted while shutting down channel for service %s", serviceName);
-            try {
-                ((ManagedChannel) channel).shutdownNow();
-            } catch (Exception ex) {
-                LOG.errorf(ex, "Error forcing shutdown of channel for service %s", serviceName);
-            }
+            closeChannelQuietly(channel, serviceName);
         } catch (Exception e) {
             LOG.errorf(e, "Error shutting down channel for service %s", serviceName);
-            try {
-                if (channel instanceof ManagedChannel) {
-                    ((ManagedChannel) channel).shutdownNow();
-                }
-            } catch (Exception ex) {
-                LOG.errorf(ex, "Error forcing shutdown of channel for service %s", serviceName);
+            closeChannelQuietly(channel, serviceName);
+        }
+    }
+
+    private void closeChannelQuietly(Channel channel, String serviceName) {
+        try {
+            if (channel instanceof ManagedChannel mc) {
+                mc.shutdownNow();
+            } else if (channel instanceof RoundRobinChannel rrc) {
+                rrc.close();
+            } else if (channel instanceof StorkGrpcChannel sgc) {
+                sgc.close();
             }
+        } catch (Exception e) {
+            LOG.tracef("Error during quiet shutdown of channel for service %s: %s", serviceName, e.getMessage());
         }
     }
 
@@ -226,15 +231,103 @@ public class ChannelManager {
     }
 
     /**
-     * Synchronously creates a gRPC channel for the given service.
+     * Synchronously creates a gRPC channel <i>pool</i> for the given service.
      * Called inside Caffeine's atomic loader — guaranteed single-threaded per key.
+     * <p>
+     * Returns a {@link RoundRobinChannel} that holds N delegate {@link StorkGrpcChannel}s
+     * (N = {@code config.channel().channelsPerService()}), each built on its own
+     * {@link GrpcClient}. Round-robined per {@code newCall} so concurrent gRPC
+     * calls spread over N independent connections on the receiving service
+     * rather than multiplexing on one.
+     * <p>
+     * Delegate construction runs in parallel across the injected {@code executor}
+     * so a pool of 8 costs ~1 Stork resolution wall-clock, not 8. Without this,
+     * the first caller who triggers channel creation for an N=8 pool pays 8× the
+     * serial Stork lookup cost while their gRPC request sits timing out —
+     * observed as intake's {@code uploadPipeDoc} 30s timeouts on the first crawl
+     * after restart.
      */
     private Channel createChannelSync(String serviceName) {
-        // Create HTTP client options for TLS configuration (Quarkus pattern)
+        // Per-service override via MP Config lookup. Prefer this over the
+        // @ConfigMapping Map<String,Integer> because service names with
+        // dashes (e.g. "opensearch-sink", "semantic-manager", "connector-admin")
+        // don't round-trip through @ConfigMapping Map keys cleanly under
+        // Quarkus 3.34 — direct property lookup always works.
+        int defaultSize = config.channel().channelsPerService();
+        int poolSize = Math.max(1,
+                ConfigProvider.getConfig()
+                        .getOptionalValue("pipestream.dynamic-grpc.channel.per-service." + serviceName, Integer.class)
+                        .orElse(defaultSize));
+        @SuppressWarnings("unchecked")
+        java.util.concurrent.CompletableFuture<Object[]>[] slotFutures =
+                new java.util.concurrent.CompletableFuture[poolSize];
+        for (int i = 0; i < poolSize; i++) {
+            slotFutures[i] = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
+                GrpcClient gc = buildGrpcClient(serviceName);
+                Channel ch = getChannel(serviceName, gc);
+                return new Object[]{ch, gc};
+            }, executor);
+        }
+        Channel[] delegates = new Channel[poolSize];
+        GrpcClient[] grpcClients = new GrpcClient[poolSize];
+        try {
+            for (int i = 0; i < poolSize; i++) {
+                Object[] slot = slotFutures[i].get(30, TimeUnit.SECONDS);
+                delegates[i] = (Channel) slot[0];
+                grpcClients[i] = (GrpcClient) slot[1];
+            }
+        } catch (Exception e) {
+            // Clean up anything that did build — we don't want to leak half-built pools
+            for (int i = 0; i < poolSize; i++) {
+                try {
+                    Object[] slot = slotFutures[i].getNow(null);
+                    if (slot != null) {
+                        if (slot[0] instanceof StorkGrpcChannel sgc) sgc.close();
+                        if (slot[1] instanceof GrpcClient gc) gc.close();
+                    }
+                } catch (Exception ignore) {}
+            }
+            throw new RuntimeException(
+                    "Failed to build channel pool for service '" + serviceName
+                            + "' (poolSize=" + poolSize + ")", e);
+        }
+        Channel pool = new RoundRobinChannel(delegates, grpcClients);
+
+        // Wrap channel with auth interceptor if auth is enabled — wrap the pool,
+        // not the delegates, so the interceptor runs once per call and then the
+        // round-robin fans the intercepted call across a delegate.
+        Channel created = config.auth().enabled()
+                ? ClientInterceptors.intercept(pool, authInterceptor)
+                : pool;
+
+        LOG.infof("Created RoundRobinChannel for %s (pool=%d, http2MaxPoolSize=%d, multiplexingLimit=%d)",
+                serviceName, poolSize,
+                config.channel().http2MaxPoolSize(),
+                config.channel().http2MultiplexingLimit());
+        metrics.recordChannelCreated(serviceName);
+
+        return created;
+    }
+
+    /** Builds a single {@link GrpcClient} for one slot of the round-robin pool. */
+    private GrpcClient buildGrpcClient(String serviceName) {
         HttpClientOptions httpOptions = new HttpClientOptions();
         httpOptions.setHttp2ClearTextUpgrade(false); // Recommended by Quarkus
 
-        // Configure TLS if enabled (using Quarkus's SSLConfigHelper - 1:1 with Quarkus code)
+        // Vert.x HTTP/2 defaults to a single connection per host; every stream
+        // multiplexes on it and the server side ends up with one event loop
+        // doing all the inbound framing. http2MaxPoolSize raises the ceiling
+        // on how many TCP connections the pool will open, and
+        // http2MultiplexingLimit forces Vert.x to actually open a new one
+        // once the current connection has that many concurrent streams.
+        // Without the multiplexing limit Vert.x keeps multiplexing onto
+        // connection #1 up to the server's max-concurrent-streams (2000) and
+        // the pool sits unused. Together with the outer N-channel round-robin
+        // this fans concurrent gRPC calls out across N event loops on the
+        // receiving service.
+        httpOptions.setHttp2MaxPoolSize(config.channel().http2MaxPoolSize());
+        httpOptions.setHttp2MultiplexingLimit(config.channel().http2MultiplexingLimit());
+
         if (tlsConfig.enabled()) {
             LOG.debugf("Configuring TLS for service: %s", serviceName);
             httpOptions.setSsl(true);
@@ -250,35 +343,13 @@ public class ChannelManager {
             SSLConfigHelper.configurePfxKeyCertOptions(httpOptions, tlsConfig.keyCertificateP12());
 
             httpOptions.setVerifyHost(tlsConfig.verifyHostname());
-
-            LOG.infof("TLS configured for service %s: trustAll=%s, verifyHostname=%s",
-                    serviceName, tlsConfig.trustAll(), tlsConfig.verifyHostname());
         }
 
-        // Create gRPC client options with HTTP options and message size limits
         GrpcClientOptions clientOptions = new GrpcClientOptions()
                 .setTransportOptions(httpOptions)
                 .setMaxMessageSize(config.channel().maxInboundMessageSize());
 
-        LOG.debugf("Creating gRPC client for %s with maxInbound=%d, maxOutbound=%d",
-                serviceName,
-                config.channel().maxInboundMessageSize(),
-                config.channel().maxOutboundMessageSize());
-
-        GrpcClient grpcClient = GrpcClient.client(vertx, clientOptions);
-
-        Channel created = getChannel(serviceName, grpcClient);
-
-        // Wrap channel with auth interceptor if auth is enabled
-        if (config.auth().enabled()) {
-            created = ClientInterceptors.intercept(created, authInterceptor);
-            LOG.debugf("Auth interceptor applied to channel for service: %s", serviceName);
-        }
-
-        LOG.debugf("Created StorkGrpcChannel for %s", serviceName);
-        metrics.recordChannelCreated(serviceName);
-
-        return created;
+        return GrpcClient.client(vertx, clientOptions);
     }
 
     private Channel getChannel(String serviceName, GrpcClient grpcClient) {

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/ChannelManager.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/ChannelManager.java
@@ -57,6 +57,15 @@ public class ChannelManager {
 
     private static final Logger LOG = Logger.getLogger(ChannelManager.class);
 
+    /**
+     * MP-Config property prefix for per-service round-robin pool size overrides.
+     * Must mirror {@link DynamicGrpcConfig}'s {@code @ConfigMapping(prefix=...)}
+     * so direct lookups (needed for service names containing dashes that
+     * Quarkus 3.34's @ConfigMapping Map keys mangle) resolve from the same
+     * namespace as the structured config. Touch one, touch the other.
+     */
+    static final String PER_SERVICE_OVERRIDE_PREFIX = "quarkus.dynamic-grpc.channel.per-service.";
+
     @Inject
     Vertx vertx;
 
@@ -253,10 +262,14 @@ public class ChannelManager {
         // dashes (e.g. "opensearch-sink", "semantic-manager", "connector-admin")
         // don't round-trip through @ConfigMapping Map keys cleanly under
         // Quarkus 3.34 — direct property lookup always works.
+        //
+        // The prefix MUST match DynamicGrpcConfig's @ConfigMapping prefix
+        // ("quarkus.dynamic-grpc"), otherwise the override is silently
+        // ignored and every service falls back to channelsPerService().
         int defaultSize = config.channel().channelsPerService();
         int poolSize = Math.max(1,
                 ConfigProvider.getConfig()
-                        .getOptionalValue("pipestream.dynamic-grpc.channel.per-service." + serviceName, Integer.class)
+                        .getOptionalValue(PER_SERVICE_OVERRIDE_PREFIX + serviceName, Integer.class)
                         .orElse(defaultSize));
         @SuppressWarnings("unchecked")
         java.util.concurrent.CompletableFuture<Object[]>[] slotFutures =

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/ChannelManager.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/ChannelManager.java
@@ -31,7 +31,9 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -256,49 +258,94 @@ public class ChannelManager {
      * observed as intake's {@code uploadPipeDoc} 30s timeouts on the first crawl
      * after restart.
      */
+    /**
+     * One slot of a {@link RoundRobinChannel} pool: a {@link Channel} bound
+     * to the {@link GrpcClient} that backs its HTTP/2 connection pool. Both
+     * are closed together via {@link #closeSlot(Slot)} on cleanup or eviction.
+     */
+    private record Slot(Channel channel, GrpcClient grpcClient) {}
+
+    private static void closeSlot(Slot s) {
+        try {
+            if (s.channel() instanceof StorkGrpcChannel sgc) {
+                sgc.close();
+            }
+        } catch (Exception ignore) { /* best-effort cleanup */ }
+        try {
+            s.grpcClient().close();
+        } catch (Exception ignore) { /* best-effort cleanup */ }
+    }
+
     private Channel createChannelSync(String serviceName) {
-        // Per-service override via MP Config lookup. Prefer this over the
-        // @ConfigMapping Map<String,Integer> because service names with
-        // dashes (e.g. "opensearch-sink", "semantic-manager", "connector-admin")
-        // don't round-trip through @ConfigMapping Map keys cleanly under
-        // Quarkus 3.34 — direct property lookup always works.
+        // Per-service override resolution order:
+        //  1. @ConfigMapping Map<String,Integer> perService() — typed and
+        //     structured. Works for Stork keys without dashes (e.g. "embedder",
+        //     "engine", "repository").
+        //  2. Direct MP-Config property lookup at the same prefix — covers
+        //     service names containing dashes (e.g. "opensearch-sink",
+        //     "semantic-manager") that Quarkus 3.34's @ConfigMapping Map keys
+        //     mangle. Same property as #1, so the two cannot disagree.
         //
-        // The prefix MUST match DynamicGrpcConfig's @ConfigMapping prefix
-        // ("quarkus.dynamic-grpc"), otherwise the override is silently
-        // ignored and every service falls back to channelsPerService().
+        // Both paths share the canonical prefix "quarkus.dynamic-grpc" — the
+        // direct lookup must mirror DynamicGrpcConfig's @ConfigMapping prefix
+        // (locked by PerServiceOverridePrefixTest).
         int defaultSize = config.channel().channelsPerService();
+        Integer mapOverride = config.channel().perService().get(serviceName);
         int poolSize = Math.max(1,
-                ConfigProvider.getConfig()
-                        .getOptionalValue(PER_SERVICE_OVERRIDE_PREFIX + serviceName, Integer.class)
-                        .orElse(defaultSize));
-        @SuppressWarnings("unchecked")
-        java.util.concurrent.CompletableFuture<Object[]>[] slotFutures =
-                new java.util.concurrent.CompletableFuture[poolSize];
+                mapOverride != null
+                        ? mapOverride
+                        : ConfigProvider.getConfig()
+                                .getOptionalValue(PER_SERVICE_OVERRIDE_PREFIX + serviceName, Integer.class)
+                                .orElse(defaultSize));
+
+        // Pool-build cleanup contract:
+        //  - poolFailed flag is set BEFORE the cleanup loop runs, so any
+        //    slot that completes asynchronously after we've given up still
+        //    hits the whenComplete handler and gets closed.
+        //  - The inner try/catch around getChannel() closes the GrpcClient
+        //    if the Channel build throws — otherwise that orphan client
+        //    would never reach the Slot envelope and never get closed.
+        AtomicBoolean poolFailed = new AtomicBoolean(false);
+        List<CompletableFuture<Slot>> slotFutures = new ArrayList<>(poolSize);
         for (int i = 0; i < poolSize; i++) {
-            slotFutures[i] = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
+            CompletableFuture<Slot> f = CompletableFuture.supplyAsync(() -> {
                 GrpcClient gc = buildGrpcClient(serviceName);
-                Channel ch = getChannel(serviceName, gc);
-                return new Object[]{ch, gc};
-            }, executor);
+                try {
+                    Channel ch = getChannel(serviceName, gc);
+                    return new Slot(ch, gc);
+                } catch (Throwable t) {
+                    try { gc.close(); } catch (Exception ignore) { /* shutting down */ }
+                    throw t;
+                }
+            }, executor).whenComplete((slot, err) -> {
+                if (slot != null && poolFailed.get()) {
+                    closeSlot(slot);
+                }
+            });
+            slotFutures.add(f);
         }
+
         Channel[] delegates = new Channel[poolSize];
         GrpcClient[] grpcClients = new GrpcClient[poolSize];
         try {
+            // Single 30s budget across the whole pool — the parallel point of
+            // CompletableFuture.supplyAsync is wasted if we then serialise
+            // .get(30s, ...) per slot (10s + 30s + ... == late failure).
+            CompletableFuture.allOf(slotFutures.toArray(new CompletableFuture[0]))
+                    .get(30, TimeUnit.SECONDS);
             for (int i = 0; i < poolSize; i++) {
-                Object[] slot = slotFutures[i].get(30, TimeUnit.SECONDS);
-                delegates[i] = (Channel) slot[0];
-                grpcClients[i] = (GrpcClient) slot[1];
+                Slot s = slotFutures.get(i).getNow(null);
+                delegates[i] = s.channel();
+                grpcClients[i] = s.grpcClient();
             }
         } catch (Exception e) {
-            // Clean up anything that did build — we don't want to leak half-built pools
-            for (int i = 0; i < poolSize; i++) {
-                try {
-                    Object[] slot = slotFutures[i].getNow(null);
-                    if (slot != null) {
-                        if (slot[0] instanceof StorkGrpcChannel sgc) sgc.close();
-                        if (slot[1] instanceof GrpcClient gc) gc.close();
-                    }
-                } catch (Exception ignore) {}
+            poolFailed.set(true);
+            for (CompletableFuture<Slot> f : slotFutures) {
+                f.cancel(true);
+                Slot done = f.getNow(null);
+                if (done != null) {
+                    closeSlot(done);
+                }
             }
             throw new RuntimeException(
                     "Failed to build channel pool for service '" + serviceName

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/RoundRobinChannel.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/RoundRobinChannel.java
@@ -1,0 +1,97 @@
+package ai.pipestream.quarkus.dynamicgrpc;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.MethodDescriptor;
+import io.quarkus.grpc.runtime.stork.StorkGrpcChannel;
+import io.vertx.grpc.client.GrpcClient;
+import org.jboss.logging.Logger;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A gRPC {@link Channel} that round-robins every {@code newCall} across N
+ * underlying delegate channels. Each delegate holds its own Vert.x
+ * {@code GrpcClient} → its own HTTP client pool → its own TCP/HTTP/2
+ * connection(s) to each resolved service instance.
+ *
+ * <h2>Why</h2>
+ * Vert.x's HTTP/2 client keeps one connection per host by default and
+ * multiplexes every gRPC call onto it. On the receiving service that
+ * single connection is handled by one Vert.x event loop, so inbound
+ * framing serialises on one thread regardless of how many streams the
+ * caller opens. With {@code N} round-robined channels the caller holds
+ * {@code N} independent connections, fanning inbound work out across
+ * {@code N} event loops on the receiver — the difference between one
+ * pegged event loop and N busy ones.
+ *
+ * <h2>Lifecycle</h2>
+ * {@link #close()} shuts down every delegate StorkGrpcChannel so the
+ * enclosing {@link ChannelManager} can dispose the pool on cache
+ * eviction without leaking connections.
+ */
+final class RoundRobinChannel extends Channel implements AutoCloseable {
+
+    private static final Logger LOG = Logger.getLogger(RoundRobinChannel.class);
+
+    private final Channel[] delegates;
+    private final GrpcClient[] grpcClients;
+    private final AtomicInteger counter = new AtomicInteger();
+
+    RoundRobinChannel(Channel[] delegates, GrpcClient[] grpcClients) {
+        if (delegates == null || delegates.length == 0) {
+            throw new IllegalArgumentException("RoundRobinChannel requires at least one delegate");
+        }
+        if (grpcClients == null || grpcClients.length != delegates.length) {
+            throw new IllegalArgumentException("grpcClients must be non-null and same length as delegates");
+        }
+        this.delegates = delegates;
+        this.grpcClients = grpcClients;
+    }
+
+    int size() {
+        return delegates.length;
+    }
+
+    @Override
+    public <Req, Resp> ClientCall<Req, Resp> newCall(MethodDescriptor<Req, Resp> method,
+                                                       CallOptions callOptions) {
+        int i = Math.floorMod(counter.getAndIncrement(), delegates.length);
+        return delegates[i].newCall(method, callOptions);
+    }
+
+    @Override
+    public String authority() {
+        return delegates[0].authority();
+    }
+
+    @Override
+    public void close() {
+        for (Channel c : delegates) {
+            try {
+                if (c instanceof StorkGrpcChannel sgc) {
+                    sgc.close();
+                } else if (c instanceof AutoCloseable ac) {
+                    ac.close();
+                }
+            } catch (Exception e) {
+                LOG.tracef("Error closing delegate channel: %s", e.getMessage());
+            }
+        }
+        for (GrpcClient gc : grpcClients) {
+            try {
+                gc.close();
+            } catch (Exception e) {
+                LOG.tracef("Error closing GrpcClient: %s", e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RoundRobinChannel{size=" + delegates.length + ", next="
+                + Math.floorMod(counter.get(), delegates.length) + "}";
+    }
+}

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/RoundRobinChannel.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/RoundRobinChannel.java
@@ -8,6 +8,7 @@ import io.quarkus.grpc.runtime.stork.StorkGrpcChannel;
 import io.vertx.grpc.client.GrpcClient;
 import org.jboss.logging.Logger;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -38,6 +39,7 @@ final class RoundRobinChannel extends Channel implements AutoCloseable {
     private final Channel[] delegates;
     private final GrpcClient[] grpcClients;
     private final AtomicInteger counter = new AtomicInteger();
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     RoundRobinChannel(Channel[] delegates, GrpcClient[] grpcClients) {
         if (delegates == null || delegates.length == 0) {
@@ -66,8 +68,18 @@ final class RoundRobinChannel extends Channel implements AutoCloseable {
         return delegates[0].authority();
     }
 
+    /**
+     * Closes every delegate channel and {@link GrpcClient}. Idempotent — the
+     * second and subsequent invocations are no-ops, because some underlying
+     * Vert.x clients log or throw on double-close, and the eviction listener
+     * is not the only path that can call {@code close()} (e.g. a future
+     * explicit shutdown hook).
+     */
     @Override
     public void close() {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
         for (Channel c : delegates) {
             try {
                 if (c instanceof StorkGrpcChannel sgc) {

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/RoundRobinChannel.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/RoundRobinChannel.java
@@ -8,7 +8,6 @@ import io.quarkus.grpc.runtime.stork.StorkGrpcChannel;
 import io.vertx.grpc.client.GrpcClient;
 import org.jboss.logging.Logger;
 
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/config/DynamicGrpcConfig.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/config/DynamicGrpcConfig.java
@@ -139,7 +139,7 @@ public interface DynamicGrpcConfig {
          * many event loops on the receiving service.
          * <p>
          * Override per target service via
-         * {@code pipestream.dynamic-grpc.channel.per-service.<serviceName>=N}.
+         * {@code quarkus.dynamic-grpc.channel.per-service.<serviceName>=N}.
          * For example, a hot-path embedder might be sized at 3, while a
          * less-used account-manager stays at the default.
          *
@@ -155,8 +155,8 @@ public interface DynamicGrpcConfig {
          * <p>
          * Example configuration:
          * <pre>
-         * pipestream.dynamic-grpc.channel.per-service.embedder=3
-         * pipestream.dynamic-grpc.channel.per-service.engine=8
+         * quarkus.dynamic-grpc.channel.per-service.embedder=3
+         * quarkus.dynamic-grpc.channel.per-service.engine=8
          * </pre>
          */
         Map<String, Integer> perService();

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/config/DynamicGrpcConfig.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/config/DynamicGrpcConfig.java
@@ -6,6 +6,7 @@ import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -88,6 +89,77 @@ public interface DynamicGrpcConfig {
          */
         @WithDefault("2147483647")
         int maxOutboundMessageSize();
+
+        /**
+         * HTTP/2 connections per remote host in the underlying Vert.x client.
+         * <p>
+         * Vert.x defaults to <b>one</b> HTTP/2 connection per host, so every gRPC
+         * stream multiplexes on a single TCP connection. That connection's
+         * event loop on the server side serialises all inbound framing work —
+         * under load we observed two server-side event loops pegged (one per
+         * caller connection) while the other 30+ loops sat idle.
+         * <p>
+         * Setting this &gt; 1 opens that many parallel HTTP/2 connections.
+         * Each connection is pinned to its own event loop on the receiver, so
+         * N connections fan out across N event loops. Concurrent gRPC calls
+         * get round-robined across the connections by Vert.x.
+         *
+         * @return number of HTTP/2 connections to open per destination host
+         */
+        @WithDefault("8")
+        int http2MaxPoolSize();
+
+        /**
+         * Multiplexing limit — the max concurrent streams Vert.x will multiplex
+         * onto a single HTTP/2 connection before it opens a new connection
+         * from the pool.
+         * <p>
+         * Must be strictly less than the server's advertised max-concurrent-streams
+         * (we set 2000), otherwise Vert.x treats one connection as infinite
+         * capacity and <b>never</b> opens connection #2 in the pool. Pair with
+         * {@link #http2MaxPoolSize()}: with pool=8 and limit=4, the client opens
+         * connection #2 as soon as #1 has 4 concurrent streams, up to 8
+         * connections total.
+         * <p>
+         * The low limit is deliberate: each new connection lands on a fresh
+         * event loop on the receiving service, so a low multiplexing limit
+         * fans inbound work out fast. Was 64 — under real pipeline load we
+         * never got close, so the pool sat idle.
+         *
+         * @return max concurrent streams per HTTP/2 connection before pool grows
+         */
+        @WithDefault("4")
+        int http2MultiplexingLimit();
+
+        /**
+         * Default number of independent gRPC {@code Channel}s the manager
+         * holds per service. Requests are round-robined across these channels.
+         * Each channel has its own {@code GrpcClient} / HTTP client /
+         * connection pool — so effectively fans inbound work out across that
+         * many event loops on the receiving service.
+         * <p>
+         * Override per target service via
+         * {@code pipestream.dynamic-grpc.channel.per-service.<serviceName>=N}.
+         * For example, a hot-path embedder might be sized at 3, while a
+         * less-used account-manager stays at the default.
+         *
+         * @return number of parallel channels per service cache entry
+         */
+        @WithDefault("4")
+        int channelsPerService();
+
+        /**
+         * Per-service overrides for {@link #channelsPerService()}. Key is the
+         * Stork/Consul service name (e.g. {@code embedder}, {@code engine}),
+         * value is the desired channel count for that specific service.
+         * <p>
+         * Example configuration:
+         * <pre>
+         * pipestream.dynamic-grpc.channel.per-service.embedder=3
+         * pipestream.dynamic-grpc.channel.per-service.engine=8
+         * </pre>
+         */
+        Map<String, Integer> perService();
 
         /**
          * gRPC call deadline in milliseconds.

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/metrics/DynamicGrpcMetrics.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/metrics/DynamicGrpcMetrics.java
@@ -9,6 +9,7 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
@@ -42,6 +43,14 @@ public class DynamicGrpcMetrics {
 
     private final AtomicInteger activeChannels = new AtomicInteger(0);
 
+    // Per-service Counter caches for hot-path methods. Avoids re-calling
+    // Counter.builder(...).register(registry) on every gRPC dispatch —
+    // Micrometer's internal registry lookup is lock-protected and can pin
+    // carrier threads under virtual-thread load.
+    private final ConcurrentHashMap<String, Counter> clientCreatedSuccessCounters = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Counter> cacheHitCounters = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Counter> cacheMissCounters = new ConcurrentHashMap<>();
+
     /**
      * Returns the MeterRegistry if available, or null if metrics are disabled.
      */
@@ -58,13 +67,14 @@ public class DynamicGrpcMetrics {
         MeterRegistry registry = getRegistry();
         if (registry == null) return;
 
-        Counter.builder(METRIC_PREFIX + ".client.created")
-                .tag("service", serviceName)
-                .tag("result", "success")
-                .tag("exception", "none")
-                .description("Number of gRPC clients successfully created")
-                .register(registry)
-                .increment();
+        clientCreatedSuccessCounters.computeIfAbsent(serviceName, name ->
+                Counter.builder(METRIC_PREFIX + ".client.created")
+                        .tag("service", name)
+                        .tag("result", "success")
+                        .tag("exception", "none")
+                        .description("Number of gRPC clients successfully created")
+                        .register(registry)
+        ).increment();
     }
 
     /**
@@ -133,11 +143,12 @@ public class DynamicGrpcMetrics {
         MeterRegistry registry = getRegistry();
         if (registry == null) return;
 
-        Counter.builder(METRIC_PREFIX + ".cache.hit")
-                .tag("service", serviceName)
-                .description("Number of channel cache hits")
-                .register(registry)
-                .increment();
+        cacheHitCounters.computeIfAbsent(serviceName, name ->
+                Counter.builder(METRIC_PREFIX + ".cache.hit")
+                        .tag("service", name)
+                        .description("Number of channel cache hits")
+                        .register(registry)
+        ).increment();
     }
 
     /**
@@ -149,11 +160,12 @@ public class DynamicGrpcMetrics {
         MeterRegistry registry = getRegistry();
         if (registry == null) return;
 
-        Counter.builder(METRIC_PREFIX + ".cache.miss")
-                .tag("service", serviceName)
-                .description("Number of channel cache misses")
-                .register(registry)
-                .increment();
+        cacheMissCounters.computeIfAbsent(serviceName, name ->
+                Counter.builder(METRIC_PREFIX + ".cache.miss")
+                        .tag("service", name)
+                        .description("Number of channel cache misses")
+                        .register(registry)
+        ).increment();
     }
 
     /**

--- a/quarkus-dynamic-grpc/runtime/src/test/java/ai/pipestream/quarkus/dynamicgrpc/PerServiceOverridePrefixTest.java
+++ b/quarkus-dynamic-grpc/runtime/src/test/java/ai/pipestream/quarkus/dynamicgrpc/PerServiceOverridePrefixTest.java
@@ -1,0 +1,35 @@
+package ai.pipestream.quarkus.dynamicgrpc;
+
+import ai.pipestream.quarkus.dynamicgrpc.config.DynamicGrpcConfig;
+import io.smallrye.config.ConfigMapping;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the per-service override property prefix used by
+ * {@link ChannelManager#PER_SERVICE_OVERRIDE_PREFIX} to the
+ * {@link DynamicGrpcConfig} {@code @ConfigMapping} prefix.
+ * <p>
+ * If these two ever drift apart, every {@code per-service.<name>} override
+ * is silently ignored at runtime — not a compile failure, not a startup
+ * failure, just every service quietly falling back to the default pool
+ * size. This regression test makes that drift a build break instead.
+ */
+class PerServiceOverridePrefixTest {
+
+    @Test
+    void perServiceOverridePrefixMatchesConfigMapping() {
+        ConfigMapping mapping = DynamicGrpcConfig.class.getAnnotation(ConfigMapping.class);
+        assertThat(mapping)
+                .as("DynamicGrpcConfig must keep its @ConfigMapping annotation")
+                .isNotNull();
+
+        String expected = mapping.prefix() + ".channel.per-service.";
+
+        assertThat(ChannelManager.PER_SERVICE_OVERRIDE_PREFIX)
+                .as("ChannelManager must look up per-service overrides under "
+                        + "the same root as DynamicGrpcConfig's @ConfigMapping prefix")
+                .isEqualTo(expected);
+    }
+}

--- a/quarkus-dynamic-grpc/runtime/src/test/java/ai/pipestream/quarkus/dynamicgrpc/RoundRobinChannelTest.java
+++ b/quarkus-dynamic-grpc/runtime/src/test/java/ai/pipestream/quarkus/dynamicgrpc/RoundRobinChannelTest.java
@@ -1,0 +1,311 @@
+package ai.pipestream.quarkus.dynamicgrpc;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.MethodDescriptor;
+import io.vertx.core.Future;
+import io.vertx.grpc.client.GrpcClient;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link RoundRobinChannel}. No Quarkus / no real gRPC — pure
+ * structural correctness so we can guarantee the round-robin contract that
+ * {@code ChannelManager.createChannelSync} relies on for fan-out across
+ * multiple HTTP/2 connections per service.
+ *
+ * <p>Lives in the same package as {@code RoundRobinChannel} so it can use
+ * the package-private constructor directly.</p>
+ */
+class RoundRobinChannelTest {
+
+    /**
+     * Every {@code newCall} must land on the next delegate in a strict
+     * round-robin sequence. With 4 delegates and 4000 calls each delegate
+     * must receive exactly 1000.
+     */
+    @Test
+    void newCall_distributesEvenlyAcrossDelegates() {
+        int n = 4;
+        int callsPerDelegate = 1000;
+        CountingChannel[] delegates = countingChannels(n);
+        AtomicInteger[] closeCounts = new AtomicInteger[n];
+        GrpcClient[] clients = fakeGrpcClients(n, closeCounts);
+
+        RoundRobinChannel rr = new RoundRobinChannel(delegates, clients);
+
+        int total = n * callsPerDelegate;
+        for (int i = 0; i < total; i++) {
+            rr.newCall(null, CallOptions.DEFAULT);
+        }
+
+        for (int i = 0; i < n; i++) {
+            assertThat(delegates[i].newCallCount.get())
+                    .as("delegate %d should have received exactly %d calls", i, callsPerDelegate)
+                    .isEqualTo(callsPerDelegate);
+        }
+    }
+
+    /**
+     * Concurrent {@code newCall}s from many threads must still distribute
+     * evenly. Using {@code AtomicInteger.getAndIncrement()} + {@code floorMod}
+     * the bucket assignment is atomic, so even under contention every delegate
+     * must receive the same count.
+     */
+    @Test
+    void newCall_isThreadSafeUnderConcurrency() throws InterruptedException {
+        int n = 6;
+        int threads = 24;
+        int callsPerThread = 5_000;
+        int totalCalls = threads * callsPerThread;
+        // totalCalls must divide evenly by n for the strict equality assertion below
+        assertThat(totalCalls % n).isZero();
+
+        CountingChannel[] delegates = countingChannels(n);
+        GrpcClient[] clients = fakeGrpcClients(n, new AtomicInteger[n]);
+        RoundRobinChannel rr = new RoundRobinChannel(delegates, clients);
+
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+        for (int t = 0; t < threads; t++) {
+            pool.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < callsPerThread; i++) {
+                        rr.newCall(null, CallOptions.DEFAULT);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+        start.countDown();
+        assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+        pool.shutdown();
+
+        int expectedPerDelegate = totalCalls / n;
+        long sum = 0;
+        for (int i = 0; i < n; i++) {
+            int actual = delegates[i].newCallCount.get();
+            sum += actual;
+            assertThat(actual)
+                    .as("delegate %d under concurrency", i)
+                    .isEqualTo(expectedPerDelegate);
+        }
+        assertThat(sum).isEqualTo(totalCalls);
+    }
+
+    @Test
+    void constructor_rejectsEmptyDelegates() {
+        assertThatThrownBy(() -> new RoundRobinChannel(new Channel[0], new GrpcClient[0]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("at least one delegate");
+        assertThatThrownBy(() -> new RoundRobinChannel(null, new GrpcClient[0]))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void constructor_rejectsMismatchedClientsLength() {
+        Channel[] delegates = countingChannels(3);
+        GrpcClient[] tooFewClients = fakeGrpcClients(2, new AtomicInteger[2]);
+        assertThatThrownBy(() -> new RoundRobinChannel(delegates, tooFewClients))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("same length");
+        assertThatThrownBy(() -> new RoundRobinChannel(delegates, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    /**
+     * {@code close()} must call {@code close()} on every delegate that
+     * implements {@code AutoCloseable} AND on every {@code GrpcClient}.
+     * If we don't release everything, evicting a pool from the
+     * {@code ChannelManager} cache leaks N HTTP/2 connection pools.
+     */
+    @Test
+    void close_closesAllDelegatesAndClients() throws Exception {
+        int n = 5;
+        AtomicInteger[] delegateCloseCounts = new AtomicInteger[n];
+        Channel[] delegates = closeableChannels(n, delegateCloseCounts);
+        AtomicInteger[] clientCloseCounts = new AtomicInteger[n];
+        GrpcClient[] clients = fakeGrpcClients(n, clientCloseCounts);
+
+        RoundRobinChannel rr = new RoundRobinChannel(delegates, clients);
+        rr.close();
+
+        for (int i = 0; i < n; i++) {
+            assertThat(delegateCloseCounts[i].get())
+                    .as("delegate %d should be closed exactly once", i).isEqualTo(1);
+            assertThat(clientCloseCounts[i].get())
+                    .as("grpcClient %d should be closed exactly once", i).isEqualTo(1);
+        }
+    }
+
+    /**
+     * If one delegate throws on close, {@code close()} must still close the
+     * remaining delegates and all GrpcClients — no resource leaks on partial
+     * failure. The exception is logged, not propagated.
+     */
+    @Test
+    void close_continuesEvenWhenADelegateThrows() {
+        AtomicInteger[] closeCounts = {new AtomicInteger(), new AtomicInteger(), new AtomicInteger()};
+        Channel[] delegates = new Channel[]{
+                closeableChannel(closeCounts[0], false),
+                closeableChannel(closeCounts[1], true),  // throws on close
+                closeableChannel(closeCounts[2], false),
+        };
+        AtomicInteger[] clientCloses = new AtomicInteger[3];
+        GrpcClient[] clients = fakeGrpcClients(3, clientCloses);
+
+        RoundRobinChannel rr = new RoundRobinChannel(delegates, clients);
+        rr.close();
+
+        assertThat(closeCounts[0].get()).as("delegate 0 closed").isEqualTo(1);
+        assertThat(closeCounts[1].get()).as("delegate 1 attempted close").isEqualTo(1);
+        assertThat(closeCounts[2].get()).as("delegate 2 closed despite earlier throw").isEqualTo(1);
+        for (int i = 0; i < 3; i++) {
+            assertThat(clientCloses[i].get())
+                    .as("grpcClient %d still closed after delegate failure", i).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void authority_returnsFirstDelegateAuthority() {
+        Channel[] delegates = new Channel[]{
+                channelWithAuthority("first.example.com:443"),
+                channelWithAuthority("second.example.com:443"),
+        };
+        GrpcClient[] clients = fakeGrpcClients(2, new AtomicInteger[2]);
+        RoundRobinChannel rr = new RoundRobinChannel(delegates, clients);
+
+        assertThat(rr.authority()).isEqualTo("first.example.com:443");
+    }
+
+    @Test
+    void size_returnsDelegateCount() {
+        Channel[] delegates = countingChannels(7);
+        GrpcClient[] clients = fakeGrpcClients(7, new AtomicInteger[7]);
+        RoundRobinChannel rr = new RoundRobinChannel(delegates, clients);
+        assertThat(rr.size()).isEqualTo(7);
+    }
+
+    // --------------------------------------------------------------------- //
+    // helpers
+    // --------------------------------------------------------------------- //
+
+    /** Channel that just counts {@code newCall} invocations. */
+    private static class CountingChannel extends Channel {
+        final AtomicInteger newCallCount = new AtomicInteger();
+
+        @Override
+        public <Req, Resp> ClientCall<Req, Resp> newCall(MethodDescriptor<Req, Resp> method,
+                                                         CallOptions callOptions) {
+            newCallCount.incrementAndGet();
+            return null;
+        }
+
+        @Override
+        public String authority() {
+            return "counting-channel";
+        }
+    }
+
+    private static CountingChannel[] countingChannels(int n) {
+        CountingChannel[] arr = new CountingChannel[n];
+        for (int i = 0; i < n; i++) {
+            arr[i] = new CountingChannel();
+        }
+        return arr;
+    }
+
+    /** Channel that's also AutoCloseable so RoundRobinChannel.close() exercises the close path. */
+    private static Channel closeableChannel(AtomicInteger closeCount, boolean throwOnClose) {
+        return new CloseableCountingChannel(closeCount, throwOnClose);
+    }
+
+    private static Channel[] closeableChannels(int n, AtomicInteger[] outCloseCounts) {
+        Channel[] arr = new Channel[n];
+        for (int i = 0; i < n; i++) {
+            outCloseCounts[i] = new AtomicInteger();
+            arr[i] = new CloseableCountingChannel(outCloseCounts[i], false);
+        }
+        return arr;
+    }
+
+    private static class CloseableCountingChannel extends Channel implements AutoCloseable {
+        final AtomicInteger closeCount;
+        final boolean throwOnClose;
+
+        CloseableCountingChannel(AtomicInteger closeCount, boolean throwOnClose) {
+            this.closeCount = closeCount;
+            this.throwOnClose = throwOnClose;
+        }
+
+        @Override
+        public <Req, Resp> ClientCall<Req, Resp> newCall(MethodDescriptor<Req, Resp> m, CallOptions o) {
+            return null;
+        }
+
+        @Override
+        public String authority() {
+            return "closeable-channel";
+        }
+
+        @Override
+        public void close() {
+            closeCount.incrementAndGet();
+            if (throwOnClose) {
+                throw new RuntimeException("simulated delegate close failure");
+            }
+        }
+    }
+
+    private static Channel channelWithAuthority(String authority) {
+        return new Channel() {
+            @Override
+            public <Req, Resp> ClientCall<Req, Resp> newCall(MethodDescriptor<Req, Resp> m, CallOptions o) {
+                return null;
+            }
+            @Override
+            public String authority() {
+                return authority;
+            }
+        };
+    }
+
+    /**
+     * Build a fake {@link GrpcClient} via dynamic proxy. We only need
+     * {@code close()} to be observable; everything else returns {@code null}
+     * (RoundRobinChannel never calls anything else on the client).
+     */
+    private static GrpcClient[] fakeGrpcClients(int n, AtomicInteger[] outCloseCounts) {
+        GrpcClient[] clients = new GrpcClient[n];
+        for (int i = 0; i < n; i++) {
+            AtomicInteger counter = new AtomicInteger();
+            outCloseCounts[i] = counter;
+            clients[i] = (GrpcClient) Proxy.newProxyInstance(
+                    GrpcClient.class.getClassLoader(),
+                    new Class<?>[]{GrpcClient.class},
+                    (proxy, method, args) -> {
+                        if ("close".equals(method.getName())) {
+                            counter.incrementAndGet();
+                            return Future.succeededFuture();
+                        }
+                        return null;
+                    });
+        }
+        return clients;
+    }
+}

--- a/quarkus-dynamic-grpc/runtime/src/test/java/ai/pipestream/quarkus/dynamicgrpc/RoundRobinChannelTest.java
+++ b/quarkus-dynamic-grpc/runtime/src/test/java/ai/pipestream/quarkus/dynamicgrpc/RoundRobinChannelTest.java
@@ -181,6 +181,36 @@ class RoundRobinChannelTest {
         }
     }
 
+    /**
+     * Two close() calls must produce exactly one close per delegate and per
+     * client. Vert.x clients log-or-throw on double-close, and there's no
+     * single owner of {@code RoundRobinChannel.close()} long-term: Caffeine's
+     * eviction listener fires once today, but any future explicit shutdown
+     * hook would race with eviction. Idempotency stops that race from
+     * surfacing as confusing errors at shutdown.
+     */
+    @Test
+    void close_isIdempotent() {
+        AtomicInteger[] closeCounts = new AtomicInteger[3];
+        Channel[] delegates = closeableChannels(3, closeCounts);
+        AtomicInteger[] clientCloses = new AtomicInteger[3];
+        GrpcClient[] clients = fakeGrpcClients(3, clientCloses);
+
+        RoundRobinChannel rr = new RoundRobinChannel(delegates, clients);
+        rr.close();
+        rr.close();
+        rr.close();
+
+        for (int i = 0; i < 3; i++) {
+            assertThat(closeCounts[i].get())
+                    .as("delegate %d closed exactly once across 3 close() calls", i)
+                    .isEqualTo(1);
+            assertThat(clientCloses[i].get())
+                    .as("grpcClient %d closed exactly once across 3 close() calls", i)
+                    .isEqualTo(1);
+        }
+    }
+
     @Test
     void authority_returnsFirstDelegateAuthority() {
         Channel[] delegates = new Channel[]{


### PR DESCRIPTION
Two independent commits that had been sitting on local main unpushed.
Landing via PR since main requires review.

## Commits

### `d20080b` — perf(dynamic-grpc): cache Counter instances per-service

Micrometer `Counter.builder(...).register(registry)` per-call was
allocating + doing a registry-map lookup on every gRPC call. Caches
the resolved `Counter` per-service so the hot path is a single map
get. Noticeable on high-QPS services.

### `8fe0a0e` — build(platform): bump pipestream-wiremock-server 0.1.55 → 0.1.56

Consumes the new `x-test-delay-ms-header` support in wiremock 0.1.56
(used by downstream consumer-manager hang-timeout tests). Version is
touched in three aligned locations:

- `gradle/libs.versions.toml` — catalog entry
- `pipestream-server/.../ContainerConstants.WireMock.VERSION` — runtime constant for devservices / testcontainers defaults
- `pipestream-test-support/README.md` — documented default image tag

## Test plan

- [x] `./gradlew build` clean
- [ ] Downstream repos (pipestream-opensearch, platform-registration-service, pipestream-engine) pick up the new wiremock image when this lands