### PR TITLE
feat(dynamic-grpc): add getBlockingClient for blocking virtual-thread callers

### DIFF
--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/DynamicGrpcClientFactory.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/DynamicGrpcClientFactory.java
@@ -84,6 +84,33 @@ public class DynamicGrpcClientFactory implements GrpcClientFactory {
      * {@inheritDoc}
      */
     @Override
+    public <T> T getBlockingClient(String serviceName, Function<Channel, T> stubCreator) {
+        if (stubCreator == null) {
+            throw new DynamicGrpcException("Stub creator function must not be null");
+        }
+        // Resolve the channel synchronously. Virtual-thread callers tolerate
+        // the block; it pins only a carrier briefly during Stork resolution
+        // on first access (subsequent calls hit the Caffeine cache).
+        try {
+            Channel channel = getChannel(serviceName).await().indefinitely();
+            T stub = stubCreator.apply(channel);
+            metrics.recordClientCreationSuccess(serviceName);
+            return stub;
+        } catch (DynamicGrpcException e) {
+            metrics.recordClientCreationFailure(serviceName, e.getClass().getSimpleName());
+            throw e;
+        } catch (RuntimeException e) {
+            LOG.errorf(e, "Failed to create blocking stub for service: %s", serviceName);
+            metrics.recordException(e.getClass().getSimpleName(), serviceName, "stub_creation");
+            metrics.recordClientCreationFailure(serviceName, e.getClass().getSimpleName());
+            throw new DynamicGrpcException("Failed to create blocking gRPC stub for service: " + serviceName, e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Uni<Channel> getChannel(String serviceName) {
         // Validate service name
         if (serviceName == null) {

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/GrpcClientFactory.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/GrpcClientFactory.java
@@ -26,6 +26,23 @@ public interface GrpcClientFactory {
     <T extends MutinyStub> Uni<T> getClient(String serviceName, Function<Channel, T> stubCreator);
 
     /**
+     * Get a typed blocking stub using a method reference (zero reflection).
+     * <p>
+     * Intended for synchronous virtual-thread call sites that want blocking
+     * semantics without Mutiny types bleeding into their code. Stork service
+     * discovery + channel acquisition run internally; the caller thread
+     * blocks until the stub is ready. After this returns every RPC on the
+     * stub is a plain synchronous call — no {@link Uni} in the hot path.
+     *
+     * @param <T>         Generated gRPC blocking stub type
+     *                    (typically {@code io.grpc.stub.AbstractBlockingStub})
+     * @param serviceName The logical service name for discovery
+     * @param stubCreator Method reference like {@code MyServiceGrpc::newBlockingStub}
+     * @return The resolved blocking stub
+     */
+    <T> T getBlockingClient(String serviceName, Function<Channel, T> stubCreator);
+
+    /**
      * Get a raw Channel for advanced use cases.
      *
      * @param serviceName The logical service name for discovery


### PR DESCRIPTION
Adds the missing platform-side API that pipestream-engine's v2 scaffold
refactor (`7e1ff54 refactor(engine): remove Mutiny and Hibernate Reactive, migrate to blocking virtual-thread code`)
expected: `GrpcClientFactory.getBlockingClient(String, Function<Channel, T>)`.

Engine has been broken-on-compile since that refactor because the
factory only exposed the Mutiny-returning `getClient` and the raw
`getChannel(...)` — neither usable without putting `Uni` back into
engine code, which was the whole point of removing Mutiny from the
engine in the first place.

## Change

One new method on `GrpcClientFactory` + its impl on `DynamicGrpcClientFactory`.

Impl resolves the channel via `getChannel(name).await().indefinitely()`:
virtual-thread caller tolerates the brief carrier pin during first Stork
resolution; subsequent calls hit the Caffeine cache. After return,
every RPC is a plain synchronous call — no `Uni` in the hot path.

Error handling mirrors `getClient`:
- null stubCreator → immediate `DynamicGrpcException`
- stub-creation failures → metrics recorded, `DynamicGrpcException` thrown
- channel-resolution errors propagate as `DynamicGrpcException` with original cause

## Test plan

- [x] `./gradlew :quarkus-dynamic-grpc:build` green locally
- [x] pipestream-engine `feat/engine-v2-scaffold` compiles against this
      (verified via publishToMavenLocal + engine-side compile)
- [ ] Engine PR follows this one; merges after this snapshot publishes

No existing method or caller is touched. Pure additive API.