### PR TITLE
fix(test-support): bump wiremock image 0.1.55 → 0.1.56 (duplicate constant missed in #70)

### DIFF
--- a/pipestream-test-support/runtime/src/main/java/ai/pipestream/test/support/TestContainerConstants.java
+++ b/pipestream-test-support/runtime/src/main/java/ai/pipestream/test/support/TestContainerConstants.java
@@ -16,7 +16,7 @@ public final class TestContainerConstants {
     public static final class WireMock {
         private WireMock() {}
 
-        public static final String VERSION = "0.1.55";
+        public static final String VERSION = "0.1.56";
         public static final String IMAGE_PROPERTY = "pipestream.wiremock.image";
         public static final String IMAGE_ENV = "PIPESTREAM_WIREMOCK_IMAGE";
         public static final String IMAGE_ENV_FALLBACK = "WIREMOCK_IMAGE";


### PR DESCRIPTION
PR #70 bumped `pipestream-server/.../ContainerConstants.WireMock.VERSION` to `0.1.56` but the **duplicate constant** in `pipestream-test-support/.../TestContainerConstants.WireMock.VERSION` was not updated.

Most test resources (`SidecarWireMockTestResource`, `RepositoryWireMockTestResource`, `EngineWireMockTestResource`, `OpensearchWireMockTestResource`) consume `TestContainerConstants.WireMock.DEFAULT_IMAGE`, which interpolates the test-support `VERSION` — so despite the server-side bump, tests were still pulling `0.1.55` images at runtime.

**Observed symptom:** `pipestream-engine-kafka-sidecar.ConsumerManagerHangTimeoutTest` pulls
```
docker.io/pipestreamai/pipestream-wiremock-server:0.1.55
```
instead of `0.1.56`, missing the `DelayInjectionRequestFilter` that the `x-test-delay-ms` header needs — tests fail because hydration completes instantly instead of being delayed and hitting `DEADLINE_EXCEEDED`.

## Fix

One-line change: align the test-support constant with the server constant.

## Follow-up smell

Two parallel constant files with the same info is a smell (they've drifted twice now). Consider a follow-up to pick one as source of truth and have the other delegate — out of scope here.