### PR TITLE
build: upgrade Quarkus 3.34.5 → 3.34.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 group=ai.pipestream
 
 # Quarkus version — 3.32.4 had a profile=prod test bug, fixed in 3.34.1+.
-quarkusPluginVersion = "3.34.5"
-quarkusVersion = "3.34.5"
+quarkusPluginVersion = "3.34.6"
+quarkusVersion = "3.34.6"
 axionReleaseVersion=1.21.1
 protoToolchainVersion=0.7.21
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Quarkus platform BOM (aligned with gradle.properties quarkusVersion).
-quarkusVersion = "3.34.5"
+quarkusVersion = "3.34.6"
 jandex-plugin = "2.3.0"
 commons-lang3 = "3.20.0"
 opennlp-runtime = "3.0.0-M2"


### PR DESCRIPTION
Latest 3.34.x patch release. Follows
`docs/dev/UPGRADING_QUARKUS_PROCESS.md`:

- `gradle.properties`: `quarkusPluginVersion` + `quarkusVersion` → `3.34.6`
- `gradle/libs.versions.toml`: `quarkusVersion` → `3.34.6` (the source-of-truth for the Quarkus BOM)

Verified with `./gradlew clean build` → BUILD SUCCESSFUL (184 tasks, all executed fresh).

## Downstream impact

Downstream services consume the platform BOM, so they pick this up automatically on the next `pipestreamBomVersion` bump. No action needed in consumer repos unless they pin Quarkus directly (they shouldn't — the BOM drives it).

Exception: `pipestream-wiremock-server` deliberately does NOT consume `pipestream-bom` (per the doc) — upgrade it manually in a follow-up PR if desired.

## Test plan

- [x] `./gradlew clean build` in pipestream-platform green
- [ ] Merge → SNAPSHOT publishes → downstream services pick up via BOM bump