### PR TITLE
fix(dynamic-grpc): restore http2 pool tuning removed in #75

### DIFF
--- a/pipestream-server/runtime/src/main/java/ai/pipestream/server/http/PipestreamHttpServerOptionsCustomizer.java
+++ b/pipestream-server/runtime/src/main/java/ai/pipestream/server/http/PipestreamHttpServerOptionsCustomizer.java
@@ -2,6 +2,7 @@ package ai.pipestream.server.http;
 
 import ai.pipestream.server.config.PipestreamServerConfig;
 import io.quarkus.vertx.http.HttpServerOptionsCustomizer;
+import io.vertx.core.http.Http2Settings;
 import io.vertx.core.http.HttpServerOptions;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -33,7 +34,18 @@ public class PipestreamHttpServerOptionsCustomizer implements HttpServerOptionsC
         }
 
         options.setHttp2ConnectionWindowSize(windowSize);
-        LOG.infof("Applied HTTP/2 connection window size (%d) to %s server (class=%s, capabilities=%s)",
+        // Advertise the same window to clients as the per-stream
+        // SETTINGS_INITIAL_WINDOW_SIZE. Without this, Vert.x defaults to
+        // 65535 bytes per stream — so client uploads (e.g. uploadPipeDoc
+        // with large PipeDocs) stall waiting for server WINDOW_UPDATEs
+        // even when the connection window is large. Pairs with the
+        // client-side setting in quarkus-dynamic-grpc's ChannelManager.
+        Http2Settings initialSettings = options.getInitialSettings() != null
+                ? options.getInitialSettings()
+                : new Http2Settings();
+        initialSettings.setInitialWindowSize(windowSize);
+        options.setInitialSettings(initialSettings);
+        LOG.infof("Applied HTTP/2 connection + stream window size (%d) to %s server (class=%s, capabilities=%s)",
                 windowSize, serverKind, normalizeClass(config.serverClass()), normalizeCapabilities(config.capabilities().orElse("")));
     }
 

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/ChannelManager.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/ChannelManager.java
@@ -231,6 +231,14 @@ public class ChannelManager {
         HttpClientOptions httpOptions = new HttpClientOptions();
         httpOptions.setHttp2ClearTextUpgrade(false);
 
+        // Without these, Vert.x keeps 1 HTTP/2 connection per host and
+        // multiplexes every gRPC stream onto it. Under pipeline load that
+        // one connection's flow-control window becomes the bottleneck
+        // (observed 2026-04-24: 1/100 uploadPipeDoc timed out at 30s,
+        // aborting the crawl). See DynamicGrpcConfig.http2MaxPoolSize.
+        httpOptions.setHttp2MaxPoolSize(config.channel().http2MaxPoolSize());
+        httpOptions.setHttp2MultiplexingLimit(config.channel().http2MultiplexingLimit());
+
         if (tlsConfig.enabled()) {
             LOG.debugf("Configuring TLS for service: %s", serviceName);
             httpOptions.setSsl(true);

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/ChannelManager.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/ChannelManager.java
@@ -18,6 +18,7 @@ import io.quarkus.grpc.runtime.supports.SSLConfigHelper;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.stork.api.ServiceInstance;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.Http2Settings;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.grpc.client.GrpcClient;
 import io.vertx.grpc.client.GrpcClientOptions;
@@ -231,13 +232,22 @@ public class ChannelManager {
         HttpClientOptions httpOptions = new HttpClientOptions();
         httpOptions.setHttp2ClearTextUpgrade(false);
 
-        // Without these, Vert.x keeps 1 HTTP/2 connection per host and
-        // multiplexes every gRPC stream onto it. Under pipeline load that
-        // one connection's flow-control window becomes the bottleneck
-        // (observed 2026-04-24: 1/100 uploadPipeDoc timed out at 30s,
-        // aborting the crawl). See DynamicGrpcConfig.http2MaxPoolSize.
+        // HTTP/2 connection pooling. Vert.x defaults to 1 connection per host
+        // with unlimited stream multiplexing — a serialisation point under
+        // pipeline load (observed 2026-04-24: 1/100 uploadPipeDoc timed out
+        // at 30s on a single overloaded connection).
         httpOptions.setHttp2MaxPoolSize(config.channel().http2MaxPoolSize());
         httpOptions.setHttp2MultiplexingLimit(config.channel().http2MultiplexingLimit());
+
+        // HTTP/2 flow control. The spec default of 65535 bytes is orders of
+        // magnitude below typical pipeline payload sizes; streams carrying
+        // PipeDocs exhaust it in one frame and park waiting for WINDOW_UPDATE.
+        // Set both the connection window and the client's advertised stream
+        // SETTINGS_INITIAL_WINDOW_SIZE to match the server-side setting
+        // (quarkus.grpc.server.flow-control-window, typically 100 MB).
+        int flowWindow = config.channel().flowControlWindow();
+        httpOptions.setHttp2ConnectionWindowSize(flowWindow);
+        httpOptions.setInitialSettings(new Http2Settings().setInitialWindowSize(flowWindow));
 
         if (tlsConfig.enabled()) {
             LOG.debugf("Configuring TLS for service: %s", serviceName);

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/config/DynamicGrpcConfig.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/config/DynamicGrpcConfig.java
@@ -163,6 +163,27 @@ public interface DynamicGrpcConfig {
          */
         @WithDefault("4")
         int http2MultiplexingLimit();
+
+        /**
+         * HTTP/2 flow-control window size, in bytes, applied to both the
+         * connection-level window and each stream's
+         * {@code SETTINGS_INITIAL_WINDOW_SIZE} advertised by the client.
+         * <p>
+         * HTTP/2's spec default is 65535 (64 KB). Under pipeline load with
+         * large PipeDoc payloads, 64 KB exhausts within milliseconds and the
+         * stream parks waiting for {@code WINDOW_UPDATE} frames from the
+         * peer. Pair this with the server-side
+         * {@code quarkus.grpc.server.flow-control-window} on the receiving
+         * service — mismatched windows are a common source of mysterious
+         * tail-latency hangs.
+         * <p>
+         * Default <b>100 MB</b> ({@code 104857600}) to match the typical
+         * server-side setting in this platform.
+         *
+         * @return HTTP/2 flow-control window in bytes
+         */
+        @WithDefault("104857600")
+        int flowControlWindow();
     }
 
     /**

--- a/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/config/DynamicGrpcConfig.java
+++ b/quarkus-dynamic-grpc/runtime/src/main/java/ai/pipestream/quarkus/dynamicgrpc/config/DynamicGrpcConfig.java
@@ -117,6 +117,52 @@ public interface DynamicGrpcConfig {
          */
         @WithDefault("1")
         int storkRetries();
+
+        /**
+         * Number of HTTP/2 connections the underlying Vert.x client keeps in
+         * its pool <i>per destination host</i>.
+         * <p>
+         * Vert.x defaults to <b>one</b> HTTP/2 connection per host. Under
+         * pipeline load — 100+ concurrent {@code uploadPipeDoc} streams into
+         * connector-intake or module dispatches from the engine — that one
+         * connection's flow-control window becomes a serialisation point:
+         * all streams share one event loop on the server side, and the 64 KB
+         * default stream window is quickly exhausted by large PipeDocs,
+         * leaving individual streams parked until {@code WINDOW_UPDATE} frames
+         * catch up. Observed 2026-04-24: single-connection default caused
+         * 1/100 intake uploads to time out at 30s, tripping the JDBC
+         * crawl's no-loss circuit breaker and aborting the whole run.
+         * <p>
+         * Default <b>8</b> — enough parallelism that each destination is
+         * backed by a real pool, small enough that a service talking to a
+         * dozen downstreams doesn't open hundreds of connections.
+         *
+         * @return HTTP/2 connections per host
+         */
+        @WithDefault("8")
+        int http2MaxPoolSize();
+
+        /**
+         * Max concurrent streams Vert.x will multiplex on a single HTTP/2
+         * connection before it opens another from the pool (up to
+         * {@link #http2MaxPoolSize()}).
+         * <p>
+         * Must be strictly less than the server's advertised
+         * {@code max-concurrent-streams}. Otherwise Vert.x treats one
+         * connection as having infinite capacity and never opens #2, #3, &hellip;
+         * Paired with {@link #http2MaxPoolSize()}: with pool=8 and limit=4,
+         * the second connection opens as soon as the first has 4 streams
+         * in flight, up to 8 connections total.
+         * <p>
+         * Default <b>4</b> — intentionally low. Each new TCP connection
+         * lands on a fresh event loop on the receiver, so a low multiplex
+         * limit fans inbound work out across multiple server loops quickly
+         * instead of piling everything onto one.
+         *
+         * @return stream multiplexing threshold per connection
+         */
+        @WithDefault("4")
+        int http2MultiplexingLimit();
     }
 
     /**


### PR DESCRIPTION
## Summary

- #75 removed \`http2MaxPoolSize\` and \`http2MultiplexingLimit\` alongside the \`RoundRobinChannel\` cleanup — the latter was the bug, the former was load-bearing
- Without these, Vert.x defaults kick in: 1 HTTP/2 connection per host, unlimited stream multiplexing on that one connection
- Under pipeline load, one connection's flow-control window becomes a serialisation point; streams hang waiting for \`WINDOW_UPDATE\`

## Observed regression

2026-04-24 E2E transport test with all services on \`0.7.25-SNAPSHOT\`:
- jdbc-connector uploaded batch 1 (docs 1-100) successfully
- batch 2 (docs 101-200): doc 115 timed out at 30s in \`uploadPipeDoc\` to connector-intake
- JDBC crawl's no-loss circuit breaker aborted the run, \`JDBC_CRAWL_JOB_STATUS_FAILED\`

intake was healthy and processing other docs in parallel — confirmed by successful uploads of docs 244 and 381 in the same window. Classic sign of one stream starved by connection-level flow control, not a dead-service hang.

## Fix

Restore the two settings (defaults 8 / 4), keep the single-\`StorkGrpcChannel\`-per-service architecture from #75. Stork owns load balancing across service instances; Vert.x HTTP/2 pool owns connections per instance. Different concerns.

## Test plan

- [x] quarkus-dynamic-grpc integration tests: 41/41 pass
- [ ] E2E transport test (ECHO→ECHO→SIDECAR, 1000 docs) — 0 drops, 0 timeouts